### PR TITLE
feat(artemis): wire up impermanence, drop persist-retro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This repo manages live systems, disks, cluster membership, and secrets. Treat op
 - Do not change disk layouts, host networking, K3s bootstrap settings, or deploy targets as incidental cleanup.
 - Do not run commands that destroy or format disks unless the user explicitly asks for the exact host/system target.
 - When touching K3s configuration, preserve bootstrap/control-plane intent and avoid changes that could force cluster reinitialization unless explicitly requested.
+- Impermanence (`modules/nixos/impermanence.nix`) never migrates existing data. When adding or changing a `persistence.*` entry (system paths, or a host's `persistence.data`/`persistence.cache`), explicitly document or perform the matching copy of existing state into its `/persist` target before a reboot or activation that would otherwise lose it. Never assume the module migrates state for you.
 
 ## Common Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This repo manages live systems, disks, cluster membership, and secrets. Treat op
 - Do not change disk layouts, host networking, K3s bootstrap settings, or deploy targets as incidental cleanup.
 - Do not run commands that destroy or format disks unless the user explicitly asks for the exact host/system target.
 - When touching K3s configuration, preserve bootstrap/control-plane intent and avoid changes that could force cluster reinitialization unless explicitly requested.
-- Impermanence (`modules/nixos/impermanence.nix`) never migrates existing data. When adding or changing a `persistence.*` entry (system paths, or a host's `persistence.data`/`persistence.cache`), explicitly document or perform the matching copy of existing state into its `/persist` target before a reboot or activation that would otherwise lose it. Never assume the module migrates state for you.
+- Impermanence (`modules/nixos/impermanence.nix`) never migrates existing data, and on artemis `persistence.nukeRoot.enable` rolls the entire root btrfs subvolume back to empty every boot — not just `/root`. When adding or changing a `persistence.*` entry (system paths, or a host's `persistence.data`/`persistence.cache`), explicitly document or perform the matching copy of existing state into its `/persist` target before a reboot or activation that would otherwise lose it. `just migrate-persist` (`modules/hosts/artemis/migrate-persist.sh`) runs that copy on artemis itself from the live `persistence.*` config; it must be run on the target host, not from a dev checkout, and re-run after any further persistence changes before rebooting. Never assume the module migrates state for you.
 
 ## Common Commands
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -53,25 +53,27 @@ intentional and should not be "fixed" without explicit sign-off. See
   `bin/mangohudctl`, and the Vulkan `implicit_layer.d` JSON are symlinked
   through from the original package unchanged, so the overlay-without-the-
   binary path (if it were ever used) still works exactly as before.
-
-## Follow-Up Candidates
-
-- **`modules/nixos/impermanence.nix` is empty.** It declares
-  `flake.nixosModules` for nothing — no `impermanence` module is defined
-  there, and the `persistance.*` options declared in
-  `modules/nixos/base/persistence.nix` (see next item) are never consumed by
-  anything that actually wires up `nix-community/impermanence` or
-  `persist-retro` (both present as flake inputs). Several modules
-  (`firefox.nix`, `pipewire.nix`, `gaming.nix`) set `persistance.data.*` /
-  `persistance.cache.*` values that currently have no effect. This needs a
-  real design decision (which persistence backend, how directories map to
-  bind mounts) before it's touched, so it's left for a follow-up rather than
-  guessed at here.
-- **`persistance` option name is a likely misspelling of "persistence".**
-  Declared in `modules/nixos/base/persistence.nix` and used in three other
-  modules. Renaming is a mechanical but repo-wide change with no behavioral
-  effect while the options remain unwired (see above) — bundling the rename
-  with actually wiring up impermanence avoids a second churn pass.
+- **`modules/nixos/impermanence.nix` was empty and `persistance` was a
+  misspelling of "persistence".** Both follow-ups from an earlier pass are
+  now resolved together: `persistance.*` was renamed to `persistence.*`
+  everywhere it was declared or set (`modules/nixos/base/persistence.nix`,
+  `firefox.nix`, `pipewire.nix`, `gaming.nix`), and
+  `modules/nixos/impermanence.nix` now imports
+  `inputs.impermanence.nixosModules.impermanence` and wires those options to
+  real `environment.persistence` entries under `/persist`,
+  `/persist/data/home/<user>`, and `/persist/cache/home/<user>`. Enabled on
+  `artemis` only; legion hosts stay opt-in (see `persistence.enable`'s
+  default and the declarative-only entries in `modules/nixos/k3s.nix`).
+  `nix-community/impermanence` was chosen as the sole persistence backend —
+  see the next item for why `persist-retro` was dropped instead of also
+  being wired up.
+- **`persist-retro` was removed as a flake input rather than adopted.** It
+  was present alongside `impermanence` from the start but never wired to
+  anything. `persist-retro`'s value proposition is auto-migrating
+  pre-existing data into the persistent store, but that's exactly the kind
+  of implicit, hard-to-audit behavior this repo wants to avoid for a
+  destructive-by-construction feature — see the `persistence.*` guardrail in
+  `AGENTS.md` requiring explicit, documented data copies instead.
 - **`environment`'s `cachix` dependency makes evaluation fragile on
   non-`x86_64-linux` machines.** `modules/packages/environment.nix` includes
   `cachix` in the shell's `runtimePkgs`. Building `cachix` pulls in a

--- a/flake.lock
+++ b/flake.lock
@@ -1176,21 +1176,6 @@
         "type": "github"
       }
     },
-    "persist-retro": {
-      "locked": {
-        "lastModified": 1709936804,
-        "narHash": "sha256-PXLha5hQLAFasIkSO4HJn9/pUbpXo8dtUKuXYYHsh6Y=",
-        "owner": "Geometer1729",
-        "repo": "persist-retro",
-        "rev": "28b016825449dc3f893e0515abfed418baed011f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Geometer1729",
-        "repo": "persist-retro",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_3",
@@ -1255,7 +1240,6 @@
         "nix2container": "nix2container",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixpkgs": "nixpkgs_4",
-        "persist-retro": "persist-retro",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix_2",
         "website": "website",

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
 
     # system management inputs
     impermanence.url = "github:nix-community/impermanence";
-    persist-retro.url = "github:Geometer1729/persist-retro";
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     nixos-facter-modules.url = "github:numtide/nixos-facter-modules";

--- a/justfile
+++ b/justfile
@@ -32,6 +32,11 @@ sops-create path:
 disko-format system sudo="sudo":
   {{sudo}} disko -f .#{{system}} --mode destroy,format,mount
 
+# Run ON artemis, as root, before rebooting into a persistence.* change —
+# impermanence never migrates existing data into /persist on its own.
+migrate-persist flake="." sudo="sudo":
+  {{sudo}} ./modules/hosts/artemis/migrate-persist.sh {{flake}}
+
 install system sudo="sudo":
   {{sudo}} nixos-install --flake .#{{system}}
 

--- a/justfile
+++ b/justfile
@@ -34,8 +34,10 @@ disko-format system sudo="sudo":
 
 # Run ON artemis, as root, before rebooting into a persistence.* change —
 # impermanence never migrates existing data into /persist on its own.
+# jq/rsync aren't guaranteed to be on PATH outside the dev shell, so pull
+# them in explicitly rather than assuming the target environment has them.
 migrate-persist flake="." sudo="sudo":
-  {{sudo}} ./modules/hosts/artemis/migrate-persist.sh {{flake}}
+  {{sudo}} nix shell nixpkgs#jq nixpkgs#rsync -c ./modules/hosts/artemis/migrate-persist.sh {{flake}}
 
 install system sudo="sudo":
   {{sudo}} nixos-install --flake .#{{system}}

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -40,10 +40,17 @@
 
       persistence = {
         enable = true;
-        # /root isn't covered by any persistence entry below, so wipe it on
-        # every boot instead of letting it silently accumulate on the
-        # (non-ephemeral) root filesystem.
-        nukeRoot.enable = true;
+        # Roll the "/rootfs" btrfs subvolume (mounted as /, see
+        # ./disko.nix) back to empty on every boot, in the initrd, before
+        # anything else is mounted. Only paths explicitly listed below
+        # survive a reboot; everything else on / is gone. device matches
+        # the same partition disko.nix mounts for /persist, /nix, etc. —
+        # any one member device of the multi-device btrfs filesystem works.
+        nukeRoot = {
+          enable = true;
+          device = "/dev/disk/by-partlabel/disk-nvme3-root";
+          subvolume = "rootfs";
+        };
 
         # Core system state that has to survive reinstalls/rebuilds: host
         # identity, generated secrets, and machine-specific network/pairing
@@ -77,7 +84,10 @@
           "Music"
           "Projects"
           "Games"
+          ".steam"
           ".local/share/Steam"
+          ".renpy"
+          ".local/share/Trash"
           {
             directory = ".ssh";
             mode = "0700";
@@ -124,6 +134,10 @@
           ".cache/heroic"
           ".cache/PrismLauncher"
           ".cache/protontricks"
+          ".local/state/DankMaterialShell"
+          ".local/state/nix"
+          ".local/state/wivrn"
+          ".local/state/xrizer"
         ];
       };
 

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -32,10 +32,101 @@
         self.nixosModules.netbird
         self.nixosModules.vr
         self.nixosModules.gaming
+        self.nixosModules.impermanence
 
         # disks
         self.diskoConfigurations.artemis
       ];
+
+      persistence = {
+        enable = true;
+        # /root isn't covered by any persistence entry below, so wipe it on
+        # every boot instead of letting it silently accumulate on the
+        # (non-ephemeral) root filesystem.
+        nukeRoot.enable = true;
+
+        # Core system state that has to survive reinstalls/rebuilds: host
+        # identity, generated secrets, and machine-specific network/pairing
+        # state. See modules/nixos/impermanence.nix for the reminder that
+        # none of this migrates automatically.
+        files = [
+          "/etc/machine-id"
+          "/var/lib/systemd/random-seed"
+          "/etc/ssh/ssh_host_ed25519_key"
+          "/etc/ssh/ssh_host_ed25519_key.pub"
+          "/etc/ssh/ssh_host_rsa_key"
+          "/etc/ssh/ssh_host_rsa_key.pub"
+        ];
+        directories = [
+          "/var/lib/nixos"
+          "/etc/NetworkManager/system-connections"
+          "/var/lib/NetworkManager"
+          "/var/lib/bluetooth"
+          "/var/lib/netbird"
+        ];
+
+        # User-level state. .mozilla/.cache/mozilla, .local/state/wireplumber,
+        # and .config/wivrn are already declared by the firefox, pipewire,
+        # and vr modules respectively, so they aren't repeated here.
+        data.directories = [
+          "Desktop"
+          "Documents"
+          "Downloads"
+          "Pictures"
+          "Videos"
+          "Music"
+          "Projects"
+          "Games"
+          ".local/share/Steam"
+          {
+            directory = ".ssh";
+            mode = "0700";
+          }
+          {
+            directory = ".gnupg";
+            mode = "0700";
+          }
+          {
+            directory = ".password-store";
+            mode = "0700";
+          }
+          {
+            directory = ".kube";
+            mode = "0700";
+          }
+          {
+            directory = ".local/share/keyrings";
+            mode = "0700";
+          }
+          ".local/share/fish"
+          ".local/share/direnv"
+          ".local/share/devenv"
+          ".local/share/zoxide"
+          ".krew"
+          ".config/fish"
+          ".config/gopass"
+          ".config/DankMaterialShell"
+          ".config/Bitwarden"
+          ".config/discord"
+          ".config/heroic"
+          ".config/PrismLauncher"
+          ".config/qBittorrent"
+          ".config/easyeffects"
+          ".local/share/heroic"
+          ".local/share/PrismLauncher"
+          ".local/share/qBittorrent"
+        ];
+        cache.directories = [
+          ".cache/devenv"
+          ".cache/direnv"
+          ".cache/nix-direnv"
+          ".cache/danksearch"
+          ".cache/heroic"
+          ".cache/PrismLauncher"
+          ".cache/protontricks"
+        ];
+      };
+
       boot = {
         loader.systemd-boot.enable = true;
         loader.systemd-boot.consoleMode = "max";

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -84,7 +84,6 @@
           "Music"
           "Projects"
           "Games"
-          ".steam"
           ".local/share/Steam"
           ".renpy"
           ".local/share/Trash"

--- a/modules/hosts/artemis/disko.nix
+++ b/modules/hosts/artemis/disko.nix
@@ -110,11 +110,12 @@
                       mountOptions = btrfsMountOptions;
                       mountpoint = "/var/log";
                     };
-                    "/home" = {
-                      mountOptions = btrfsMountOptions;
-                      mountpoint = "/home";
-                    };
-                    "/home/aidanp" = {};
+                    # /home is intentionally not its own persistent subvolume:
+                    # with impermanence enabled (modules/nixos/impermanence.nix),
+                    # only the paths explicitly listed under persistence.data/
+                    # persistence.cache are bind-mounted into $HOME from
+                    # /persist; unlisted home state is not guaranteed to
+                    # survive.
                     "/nix" = {
                       mountOptions = btrfsMountOptions;
                       mountpoint = "/nix";

--- a/modules/hosts/artemis/migrate-persist.sh
+++ b/modules/hosts/artemis/migrate-persist.sh
@@ -19,6 +19,16 @@ set -euo pipefail
 flake="${1:-/etc/nixos}"
 attr="nixosConfigurations.artemis.config"
 
+# `nix eval --impure` shells out to git for a local git+file:// flake input.
+# This script runs as root, but the checkout is normally owned by a regular
+# user, so git's ownership check ("detected dubious ownership in
+# repository") blocks it unless the path is explicitly marked safe for this
+# process. Scope that to just this flake path rather than disabling the
+# check globally for root.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="$(cd "$flake" && pwd -P)"
+
 user=$(nix eval --impure --raw "${flake}#${attr}.preferences.user.name")
 home="/home/${user}"
 

--- a/modules/hosts/artemis/migrate-persist.sh
+++ b/modules/hosts/artemis/migrate-persist.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Copy artemis's existing state into /persist before switching to (or
+# extending) a configuration with persistence.enable/persistence.nukeRoot.enable.
+#
+# impermanence never migrates data on its own (see
+# modules/nixos/impermanence.nix): once persistence.nukeRoot.enable is
+# active, anything at a listed path that hasn't been copied into /persist
+# beforehand is gone on the next boot, since the whole "/rootfs" subvolume
+# gets rolled back to empty in the initrd.
+#
+# Run this ON artemis itself, as root, against the flake checkout that has
+# the persistence entries you're about to deploy, and only reboot once it
+# reports every path synced (or intentionally skipped).
+#
+# Usage: sudo ./migrate-persist.sh [/path/to/flake-checkout]
+
+set -euo pipefail
+
+flake="${1:-/etc/nixos}"
+attr="nixosConfigurations.artemis.config"
+
+user=$(nix eval --impure --raw "${flake}#${attr}.preferences.user.name")
+home="/home/${user}"
+
+# Coerce impermanence's mixed string / { directory|file = ...; mode = ...; }
+# entries down to plain path strings.
+paths() {
+  nix eval --impure --json "${flake}#${attr}.persistence.$1" \
+    --apply 'builtins.map (e: if builtins.isString e then e else e.directory or e.file)' |
+    jq -r '.[]'
+}
+
+sync_dir() {
+  local src="$1" dst="$2"
+  if [[ ! -e "$src" ]]; then
+    echo "skip (missing): $src"
+    return
+  fi
+  mkdir -p "$dst"
+  rsync -aHAX --numeric-ids "$src/" "$dst/"
+  echo "synced dir:  $src -> $dst"
+}
+
+sync_file() {
+  local src="$1" dst="$2"
+  if [[ ! -e "$src" ]]; then
+    echo "skip (missing): $src"
+    return
+  fi
+  mkdir -p "$(dirname "$dst")"
+  rsync -aHAX --numeric-ids "$src" "$dst"
+  echo "synced file: $src -> $dst"
+}
+
+echo "== system directories -> /persist =="
+while IFS= read -r p; do
+  sync_dir "$p" "/persist${p}"
+done < <(paths directories)
+
+echo "== system files -> /persist =="
+while IFS= read -r p; do
+  sync_file "$p" "/persist${p}"
+done < <(paths files)
+
+echo "== user data directories -> /persist/data/home/${user} =="
+while IFS= read -r p; do
+  sync_dir "${home}/${p}" "/persist/data/home/${user}/${p}"
+done < <(paths data.directories)
+
+echo "== user data files -> /persist/data/home/${user} =="
+while IFS= read -r p; do
+  sync_file "${home}/${p}" "/persist/data/home/${user}/${p}"
+done < <(paths data.files)
+
+echo "== user cache directories -> /persist/cache/home/${user} =="
+while IFS= read -r p; do
+  sync_dir "${home}/${p}" "/persist/cache/home/${user}/${p}"
+done < <(paths cache.directories)
+
+echo "== user cache files -> /persist/cache/home/${user} =="
+while IFS= read -r p; do
+  sync_file "${home}/${p}" "/persist/cache/home/${user}/${p}"
+done < <(paths cache.files)
+
+echo
+echo "Done. Review any 'skip (missing)' lines above — those are fine if the"
+echo "path genuinely doesn't exist yet, but re-run this after any further"
+echo "persistence.* changes before rebooting. nukeRoot wipes anything on /"
+echo "that wasn't copied into /persist first."

--- a/modules/hosts/artemis/migrate-persist.sh
+++ b/modules/hosts/artemis/migrate-persist.sh
@@ -36,8 +36,16 @@ sync_dir() {
     echo "skip (missing): $src"
     return
   fi
-  mkdir -p "$dst"
-  rsync -aHAX --numeric-ids "$src/" "$dst/"
+  local dst_parent
+  dst_parent="$(dirname "$dst")"
+  mkdir -p "$dst_parent"
+  # No trailing slash on $src: every call site here builds $dst as some
+  # prefix + $src's own path, so basename "$src" always equals basename
+  # "$dst". That lets rsync copy the directory itself (with its own
+  # owner/mode/xattrs, not just its contents) into $dst_parent — otherwise
+  # $dst would come back root:root 0755 regardless of what the source
+  # directory's permissions were (e.g. .ssh, .gnupg, system-connections).
+  rsync -aHAX --numeric-ids "$src" "$dst_parent/"
   echo "synced dir:  $src -> $dst"
 }
 

--- a/modules/hosts/artemis/migrate-persist.sh
+++ b/modules/hosts/artemis/migrate-persist.sh
@@ -100,6 +100,22 @@ while IFS= read -r p; do
   sync_file "${home}/${p}" "/persist/cache/home/${user}/${p}"
 done < <(paths cache.files)
 
+# The `mkdir -p` calls in sync_dir/sync_file run as root and only create
+# ancestor directories that aren't themselves a declared persistence entry
+# (e.g. .config, .local, .local/share, .local/state, .cache — none of
+# which are individually listed, only paths nested inside them). Left
+# alone those come back root:root, and impermanence mirrors that ownership
+# onto the live $HOME tree at boot instead of creating it fresh as the
+# user, breaking every app that expects to write into its own XDG dirs.
+# Force correct ownership on the whole user tree; this only touches
+# owner:group, never mode, so it doesn't disturb the explicit 0700 entries
+# (.ssh, .gnupg, etc.) synced above.
+echo "== fixing ownership under /persist/{data,cache}/home/${user} =="
+group="$(id -gn "$user")"
+for root in "/persist/data/home/${user}" "/persist/cache/home/${user}"; do
+  [[ -e "$root" ]] && chown -R "${user}:${group}" "$root"
+done
+
 echo
 echo "Done. Review any 'skip (missing)' lines above — those are fine if the"
 echo "path genuinely doesn't exist yet, but re-run this after any further"

--- a/modules/nixos/base/persistence.nix
+++ b/modules/nixos/base/persistence.nix
@@ -1,7 +1,7 @@
 {
   flake.nixosModules.base = {lib, ...}: {
-    options.persistance = {
-      enable = lib.mkEnableOption "enable persistance";
+    options.persistence = {
+      enable = lib.mkEnableOption "enable persistence";
 
       nukeRoot.enable = lib.mkEnableOption "Destroy /root on every boot";
 

--- a/modules/nixos/base/persistence.nix
+++ b/modules/nixos/base/persistence.nix
@@ -3,7 +3,39 @@
     options.persistence = {
       enable = lib.mkEnableOption "enable persistence";
 
-      nukeRoot.enable = lib.mkEnableOption "Destroy /root on every boot";
+      nukeRoot = {
+        enable = lib.mkEnableOption "roll the btrfs root subvolume back to an empty subvolume on every boot";
+
+        device = lib.mkOption {
+          type = lib.types.str;
+          default = "";
+          example = "/dev/disk/by-partlabel/disk-nvme3-root";
+          description = ''
+            Block device (or `/dev/disk/by-*` path) belonging to the btrfs
+            filesystem whose top-level subvolume (`subvolid=5`) is mounted
+            in the initrd to perform the rollback. For a multi-device btrfs
+            filesystem, any one of its member devices works.
+          '';
+        };
+
+        subvolume = lib.mkOption {
+          type = lib.types.str;
+          default = "rootfs";
+          description = ''
+            Name of the top-level btrfs subvolume that is mounted as `/`
+            and gets moved aside and recreated empty on every boot.
+          '';
+        };
+
+        maxAge = lib.mkOption {
+          type = lib.types.int;
+          default = 30;
+          description = ''
+            Age in days after which old roots under `/old_roots` on the
+            rollback device are deleted.
+          '';
+        };
+      };
 
       volumeGroup = lib.mkOption {
         default = "btrfs_vg";

--- a/modules/nixos/firefox.nix
+++ b/modules/nixos/firefox.nix
@@ -2,11 +2,11 @@
   flake.nixosModules.firefox = {
     programs.firefox.enable = true;
 
-    persistance.data.directories = [
+    persistence.data.directories = [
       ".mozilla"
     ];
 
-    persistance.cache.directories = [
+    persistence.cache.directories = [
       ".cache/mozilla"
     ];
   };

--- a/modules/nixos/gaming.nix
+++ b/modules/nixos/gaming.nix
@@ -1,12 +1,9 @@
 {self, ...}: {
   flake.nixosModules.gaming = {
-    config,
     pkgs,
     lib,
     ...
-  }: let
-    user = config.preferences.user.name;
-  in {
+  }: {
     environment.systemPackages = with pkgs; [
       boxflat
       self.packages.${pkgs.stdenv.hostPlatform.system}.mangohud
@@ -81,13 +78,15 @@
         ];
       };
     };
-    # ~/.steam is just Steam's own compatibility-symlink shortcut into the
-    # real library at ~/.local/share/Steam (the only one actually persisted,
-    # see persistence.data.directories on artemis) — not independent data,
-    # so recreate it declaratively every boot instead of persisting it.
-    systemd.tmpfiles.rules = [
-      "L+ /home/${user}/.steam - - - - /home/${user}/.local/share/Steam"
-    ];
+    # ~/.steam is intentionally not managed here: Steam's own launcher
+    # (steam.sh) expects it to be a real directory containing its own
+    # internal symlinks (.steam/steam, .steam/root, .steam/bin32, ... into
+    # ~/.local/share/Steam), and recreates that structure itself on every
+    # launch if missing — cheap, no real data. Only ~/.local/share/Steam
+    # (the actual library) is persisted; see persistence.data.directories
+    # on artemis. Do not turn ~/.steam itself into a symlink to
+    # ~/.local/share/Steam — that breaks steam.sh (tried, produced
+    # "couldn't set up steam data" errors).
     hardware.graphics = {
       enable = true;
       enable32Bit = true;

--- a/modules/nixos/gaming.nix
+++ b/modules/nixos/gaming.nix
@@ -1,9 +1,12 @@
 {self, ...}: {
   flake.nixosModules.gaming = {
+    config,
     pkgs,
     lib,
     ...
-  }: {
+  }: let
+    user = config.preferences.user.name;
+  in {
     environment.systemPackages = with pkgs; [
       boxflat
       self.packages.${pkgs.stdenv.hostPlatform.system}.mangohud
@@ -78,6 +81,13 @@
         ];
       };
     };
+    # ~/.steam is just Steam's own compatibility-symlink shortcut into the
+    # real library at ~/.local/share/Steam (the only one actually persisted,
+    # see persistence.data.directories on artemis) — not independent data,
+    # so recreate it declaratively every boot instead of persisting it.
+    systemd.tmpfiles.rules = [
+      "L+ /home/${user}/.steam - - - - /home/${user}/.local/share/Steam"
+    ];
     hardware.graphics = {
       enable = true;
       enable32Bit = true;

--- a/modules/nixos/gaming.nix
+++ b/modules/nixos/gaming.nix
@@ -104,7 +104,7 @@
       '')
     ];
 
-    persistance.cache.directories = [
+    persistence.cache.directories = [
       ".config/wivrn"
     ];
 

--- a/modules/nixos/hyprland/default.nix
+++ b/modules/nixos/hyprland/default.nix
@@ -45,6 +45,19 @@
       };
     };
 
+    # hjem.target/hjem-activate@ (which link hjem.users.${user}.files below,
+    # including the hyprland config) are only WantedBy=multi-user.target,
+    # which pulls them in but doesn't order them relative to anything else
+    # also wanted by that target — Requires/WantedBy alone don't imply
+    # ordering. On persistent /home this raced harmlessly since hjem had
+    # nothing to do; with impermanence wiping / on every boot, hjem has to
+    # relink everything from scratch and can lose the race, starting
+    # Hyprland before its config exists. Make greetd wait for it.
+    systemd.services.greetd = {
+      wants = ["hjem-activate@${user}.service"];
+      after = ["hjem-activate@${user}.service"];
+    };
+
     environment.systemPackages = with pkgs; [
       rose-pine-hyprcursor
       hyprpolkitagent

--- a/modules/nixos/impermanence.nix
+++ b/modules/nixos/impermanence.nix
@@ -1,1 +1,47 @@
-{}
+{inputs, ...}: {
+  flake.nixosModules.impermanence = {
+    config,
+    lib,
+    ...
+  }: let
+    cfg = config.persistence;
+    user = config.preferences.user.name;
+  in {
+    imports = [
+      inputs.impermanence.nixosModules.impermanence
+    ];
+
+    config = lib.mkIf cfg.enable {
+      fileSystems."/persist".neededForBoot = true;
+
+      # impermanence only bind-mounts the paths listed below; it does not
+      # migrate any data that already exists at those paths. Before
+      # rebooting (or running an activation that would otherwise lose
+      # unpersisted state) after adding or changing an entry here, manually
+      # copy the current contents into its target under /persist, e.g.:
+      #   cp -a /etc/machine-id /persist/etc/machine-id
+      #   cp -a /home/${user}/Projects /persist/data/home/${user}/Projects
+      # Never assume this module migrates existing state for you.
+      environment.persistence = {
+        "/persist" = {
+          inherit (cfg) directories files;
+        };
+
+        "/persist/data".users.${user} = {
+          directories = cfg.data.directories;
+          files = cfg.data.files;
+        };
+
+        "/persist/cache".users.${user} = {
+          directories = cfg.cache.directories;
+          files = cfg.cache.files;
+        };
+      };
+
+      systemd.tmpfiles.rules = lib.mkIf cfg.nukeRoot.enable [
+        "R! /root"
+        "d /root 0700 root root -"
+      ];
+    };
+  };
+}

--- a/modules/nixos/impermanence.nix
+++ b/modules/nixos/impermanence.nix
@@ -87,7 +87,10 @@
       # empty subvolume is what actually gets mounted as /.
       (lib.mkIf (cfg.enable && cfg.nukeRoot.enable && config.boot.initrd.systemd.enable) {
         boot.initrd.systemd = {
-          initrdBin = [pkgs.btrfs-progs];
+          # findutils for `find` in rollbackScript below — btrfs-progs is
+          # already pulled in automatically since / is btrfs, but findutils
+          # isn't part of the default systemd-initrd tool set.
+          initrdBin = [pkgs.btrfs-progs pkgs.findutils];
           services.rollback-root = {
             description = "Roll back btrfs root subvolume to an empty subvolume";
             unitConfig.DefaultDependencies = false;

--- a/modules/nixos/impermanence.nix
+++ b/modules/nixos/impermanence.nix
@@ -2,46 +2,118 @@
   flake.nixosModules.impermanence = {
     config,
     lib,
+    pkgs,
+    utils,
     ...
   }: let
     cfg = config.persistence;
     user = config.preferences.user.name;
+
+    rootDeviceUnit = "${utils.escapeSystemdPath cfg.nukeRoot.device}.device";
+
+    # Moves the current root subvolume aside under /old_roots (pruning
+    # anything older than nukeRoot.maxAge days, recursing into nested
+    # subvolumes first since btrfs refuses to delete a non-empty one), then
+    # recreates it empty. Only ever touches the "${cfg.nukeRoot.subvolume}"
+    # top-level subvolume mounted at "/" — /persist, /nix, /log, and any
+    # leftover top-level /home are separate sibling subvolumes on the same
+    # filesystem and are never listed or descended into here.
+    rollbackScript = ''
+      mkdir /btrfs_tmp
+      mount -o subvolid=5 ${cfg.nukeRoot.device} /btrfs_tmp
+      if [[ -e /btrfs_tmp/${cfg.nukeRoot.subvolume} ]]; then
+          mkdir -p /btrfs_tmp/old_roots
+          timestamp=$(date --date="@$(stat -c %Y /btrfs_tmp/${cfg.nukeRoot.subvolume})" "+%Y-%m-%-d_%H:%M:%S")
+          mv "/btrfs_tmp/${cfg.nukeRoot.subvolume}" "/btrfs_tmp/old_roots/$timestamp"
+      fi
+
+      delete_subvolume_recursively() {
+          IFS=$'\n'
+          for i in $(btrfs subvolume list -o "$1" | cut -f 9- -d ' '); do
+              delete_subvolume_recursively "/btrfs_tmp/$i"
+          done
+          btrfs subvolume delete "$1"
+      }
+
+      for i in $(find /btrfs_tmp/old_roots/ -maxdepth 1 -mtime +${toString cfg.nukeRoot.maxAge}); do
+          delete_subvolume_recursively "$i"
+      done
+
+      btrfs subvolume create "/btrfs_tmp/${cfg.nukeRoot.subvolume}"
+      umount /btrfs_tmp
+    '';
   in {
     imports = [
       inputs.impermanence.nixosModules.impermanence
     ];
 
-    config = lib.mkIf cfg.enable {
-      fileSystems."/persist".neededForBoot = true;
+    config = lib.mkMerge [
+      (lib.mkIf cfg.enable {
+        fileSystems."/persist".neededForBoot = true;
 
-      # impermanence only bind-mounts the paths listed below; it does not
-      # migrate any data that already exists at those paths. Before
-      # rebooting (or running an activation that would otherwise lose
-      # unpersisted state) after adding or changing an entry here, manually
-      # copy the current contents into its target under /persist, e.g.:
-      #   cp -a /etc/machine-id /persist/etc/machine-id
-      #   cp -a /home/${user}/Projects /persist/data/home/${user}/Projects
-      # Never assume this module migrates existing state for you.
-      environment.persistence = {
-        "/persist" = {
-          inherit (cfg) directories files;
+        # impermanence only bind-mounts the paths listed below; it does not
+        # migrate any data that already exists at those paths. Before
+        # rebooting (or running an activation that would otherwise lose
+        # unpersisted state) after adding or changing an entry here, copy the
+        # current contents into its target under /persist, e.g.:
+        #   cp -a /etc/machine-id /persist/etc/machine-id
+        #   cp -a /home/${user}/Projects /persist/data/home/${user}/Projects
+        # On artemis, `just migrate-persist` (modules/hosts/artemis/migrate-persist.sh)
+        # does this for every path in the current persistence.* config — run
+        # it on artemis itself before rebooting. Never assume this module
+        # migrates existing state for you.
+        environment.persistence = {
+          "/persist" = {
+            inherit (cfg) directories files;
+          };
+
+          "/persist/data".users.${user} = {
+            directories = cfg.data.directories;
+            files = cfg.data.files;
+          };
+
+          "/persist/cache".users.${user} = {
+            directories = cfg.cache.directories;
+            files = cfg.cache.files;
+          };
         };
+      })
 
-        "/persist/data".users.${user} = {
-          directories = cfg.data.directories;
-          files = cfg.data.files;
+      # systemd stage 1 (the default since this flake tracks nixos-unstable):
+      # roll back before the root filesystem is mounted at all. Ordering
+      # matches the nix-community/impermanence PR #321 reference: run once
+      # the root block device shows up and hibernation resume had its
+      # chance to run first, and finish before sysroot.mount so the fresh
+      # empty subvolume is what actually gets mounted as /.
+      (lib.mkIf (cfg.enable && cfg.nukeRoot.enable && config.boot.initrd.systemd.enable) {
+        boot.initrd.systemd = {
+          initrdBin = [pkgs.btrfs-progs];
+          services.rollback-root = {
+            description = "Roll back btrfs root subvolume to an empty subvolume";
+            unitConfig.DefaultDependencies = false;
+            serviceConfig.Type = "oneshot";
+            requiredBy = ["initrd.target"];
+            before = ["sysroot.mount"];
+            requires = [rootDeviceUnit];
+            after = [
+              rootDeviceUnit
+              # Let hibernation resume run (and consume the pre-rollback
+              # root) before this alters any data.
+              "local-fs-pre.target"
+            ];
+            script = rollbackScript;
+          };
         };
+      })
 
-        "/persist/cache".users.${user} = {
-          directories = cfg.cache.directories;
-          files = cfg.cache.files;
-        };
-      };
-
-      systemd.tmpfiles.rules = lib.mkIf cfg.nukeRoot.enable [
-        "R! /root"
-        "d /root 0700 root root -"
-      ];
-    };
+      # Classic (non-systemd) initrd fallback, only relevant if systemd
+      # stage 1 is ever explicitly turned off for this host. postResumeCommands
+      # runs after the kernel's own hibernation-resume attempt, matching the
+      # "resume before rollback" ordering used in the systemd-stage-1 path
+      # above.
+      (lib.mkIf (cfg.enable && cfg.nukeRoot.enable && !config.boot.initrd.systemd.enable) {
+        boot.initrd.postResumeCommands = lib.mkAfter rollbackScript;
+      })
+    ];
   };
 }

--- a/modules/nixos/k3s.nix
+++ b/modules/nixos/k3s.nix
@@ -9,6 +9,15 @@
         allowedTCPPorts = [6443 10250];
         allowedUDPPorts = [8472];
       };
+      # Declared for future opt-in only: legion hosts don't import
+      # self.nixosModules.impermanence and persistence.enable defaults to
+      # false, so this has no effect until a host explicitly turns
+      # persistence on.
+      persistence.directories = [
+        "/var/lib/rancher/k3s"
+        "/var/lib/kubelet"
+        "/etc/rancher/k3s"
+      ];
       services.k3s = {
         enable = true;
         role = lib.mkDefault "agent";

--- a/modules/nixos/pipewire.nix
+++ b/modules/nixos/pipewire.nix
@@ -1,6 +1,6 @@
 {
   flake.nixosModules.pipewire = {pkgs, ...}: {
-    persistance.cache.directories = [
+    persistence.cache.directories = [
       ".local/state/wireplumber"
     ];
     environment.systemPackages = with pkgs; [


### PR DESCRIPTION
## Summary

- Use `nix-community/impermanence` as the only persistence backend; remove the never-wired `persist-retro` flake input (dropped from `flake.nix`/`flake.lock`).
- Rename the `persistance.*` typo to `persistence.*` everywhere it was declared/set (`modules/nixos/base/persistence.nix`, `firefox.nix`, `pipewire.nix`, `gaming.nix`).
- Implement `modules/nixos/impermanence.nix`: imports `inputs.impermanence.nixosModules.impermanence` and maps `persistence.*` options to real `environment.persistence` entries — system paths under `/persist`, user data under `/persist/data/home/<user>`, user cache under `/persist/cache/home/<user>`. Sets `/persist` `neededForBoot`.
- **Root is actually ephemeral now.** `persistence.nukeRoot` rolls the whole `"/rootfs"` btrfs subvolume (mounted as `/`) back to empty on every boot, not just `/root`: mount the filesystem at `subvolid=5`, move `rootfs` into `/old_roots/<timestamp>`, prune roots older than `nukeRoot.maxAge` days (recursing into nested subvolumes first, since btrfs won't delete a non-empty one), recreate `rootfs` empty. `/persist`, `/nix`, `/log`, and any leftover top-level `/home` are separate sibling subvolumes and are never touched. This nixpkgs pin already defaults `boot.initrd.systemd.enable = true`, so the rollback runs as a `boot.initrd.systemd.services` unit ordered before `sysroot.mount` and after the root device unit + `local-fs-pre.target` (so hibernation resume gets first crack at the disk), matching the [nix-community/impermanence PR #321](https://github.com/nix-community/impermanence/pull/321) reference. `boot.initrd.systemd.initrdBin` explicitly includes both `btrfs-progs` and `findutils` (the rollback script's `find` call needs the latter — it isn't part of the default systemd-initrd tool set the way `coreutils` is). A `postResumeCommands` fallback covers classic (non-systemd) initrd. `nukeRoot` gains `device`/`subvolume`/`maxAge` options, set on `artemis` to match its disko layout.
- Enable persistence + `nukeRoot` on `artemis` only. Legion hosts stay opt-in: `modules/nixos/k3s.nix` declares K3s state paths (`/var/lib/rancher/k3s`, `/var/lib/kubelet`, `/etc/rancher/k3s`) for future use, but they're inert since legion doesn't import the impermanence module and `persistence.enable` defaults to false.
- `modules/hosts/artemis/disko.nix`: removed the dedicated `/home` subvolume so home state is governed entirely by the explicit `persistence.data`/`persistence.cache` lists instead of being silently persisted wholesale. `/nix`, `/var/log`, `/persist`, and `/mnt/root` are unchanged.
- Populated artemis's persisted state: host identity/ssh host keys/network state at the system level; desktop folders, Projects, Games, Steam (`.local/share/Steam`), `.renpy`, `.local/share/Trash`, Kubernetes config, SSH/GPG/password-store (restrictive `0700` modes), fish/direnv/devenv/zoxide state, keyrings, several `.local/state/*` dirs (DankMaterialShell, nix, wivrn, xrizer), and various app config/cache at the user level. Entries already declared by `firefox.nix`/`pipewire.nix`/the `vr` module (`.mozilla`, `.local/state/wireplumber`, `.config/wivrn`) aren't duplicated. `~/.steam` isn't persisted or otherwise managed at all: Steam's own launcher (`steam.sh`) expects it to be a real directory containing its own internal symlinks into `.local/share/Steam` (`.steam/steam`, `.steam/root`, `.steam/bin32`, ...) and recreates that structure itself on every launch when missing. An earlier revision of this PR turned `~/.steam` itself into a symlink to `.local/share/Steam`, which broke Steam ("couldn't set up steam data") since anything `steam.sh` does at `.steam/steam` then lands inside the real library instead of at the expected compatibility path — reverted.
- Add `modules/hosts/artemis/migrate-persist.sh` (wired as `just migrate-persist`) to copy artemis's existing state into `/persist` from the live `persistence.*` config — impermanence never migrates data on its own, and with real root rollback now in place, anything not copied is gone on the next boot. Directories are rsynced without a trailing slash on the source, so the destination inherits the source directory's own owner/mode/xattrs (not just its contents) — important for `.ssh`, `.gnupg`, `system-connections`, etc. The `just migrate-persist` recipe runs the script through `nix shell nixpkgs#jq nixpkgs#rsync` rather than assuming those tools are already on the target host's `PATH`. Running as root against a user-owned checkout trips git's "dubious ownership" guard when `nix eval --impure` fetches the local `git+file://` flake input, so the script sets `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` to mark just that resolved path safe, scoped to the flake path rather than disabling the check globally for root. It also ends with a `chown -R` pass over `/persist/data/home/<user>` and `/persist/cache/home/<user>` — `mkdir -p` (used to create missing parent directories before `rsync`) runs as root and, for ancestors that aren't themselves a declared entry (`.config`, `.local`, `.local/share`, `.local/state`, `.cache`), that left them root:root, which `impermanence` then mirrored onto the live `$HOME` tree at boot. **This must be run on artemis itself, as root, before rebooting into this config**; it wasn't and couldn't be run from this sandbox. Also fixes `modules/nixos/hyprland/default.nix`'s `services.greetd` unit to `after`/`wants` `hjem-activate@<user>.service`: hjem's file linker (`smfh`, run via a system service gated only by `WantedBy=multi-user.target`, which doesn't imply ordering) had no guaranteed ordering against greetd, and with impermanence wiping `/` on every boot hjem now has real relinking work to do and can lose that race — surfaced as Hyprland starting before its `hjem`-managed config exists.
- `AGENTS.md` and `docs/IMPROVEMENTS.md` updated: a guardrail states that impermanence never migrates existing data and that `nukeRoot` now wipes the whole root filesystem (not just `/root`), pointing at `just migrate-persist`; the old "impermanence.nix is empty" / "persistance typo" follow-ups are resolved, and a note explains `persist-retro` was dropped rather than adopted.

## Why

`persistance.*` was declared but never wired to anything, and two competing persistence backends (`impermanence`, `persist-retro`) sat unused as flake inputs. `persist-retro`'s main value is auto-migrating pre-existing data into the persistent store, which is exactly the kind of implicit, hard-to-audit behavior this repo wants to avoid — instead, any new persistence entry requires an explicit, documented copy step (now scripted via `migrate-persist.sh`). A first pass wired `environment.persistence` but only wiped `/root` via tmpfiles, leaving the rest of `/` (and any unlisted `/home` state) fully persistent — this PR closes that gap with a real btrfs subvolume rollback. A follow-up review caught the rollback script's missing `findutils` dependency and two migration-script bugs (directory metadata loss, missing `jq`/`rsync` on the target); a subsequent real run against artemis surfaced the git-ownership issue, a root-owned-XDG-parent-directory bug, and a hjem/greetd ordering race, all fixed in the same PR. `.steam` was also dropped from persistence entirely (it was never independent data), with a follow-up correcting an initial attempt at replacing it with a direct symlink, which broke Steam's own expected directory layout — see below.

## Test plan

- [x] `rg persistance` / `rg persist-retro` — no matches in `.nix` sources (only historical prose remains in `docs/IMPROVEMENTS.md`, matching the intentional changelog exception)
- [x] `just fmt` — clean
- [x] `just check` — fails with a pre-existing `cachix`/IFD cross-platform eval error unrelated to this change; confirmed via `git stash` that it fails identically on the unmodified base commit (this machine is aarch64-darwin; already documented in `docs/IMPROVEMENTS.md`)
- [x] Targeted `nix eval` checks on `nixosConfigurations.artemis`: merged `persistence` config (including the newly added entries), real `environment.persistence` bind-mount entries (system/data/cache, including `0700` modes on sensitive dirs), `/persist` `neededForBoot = true`, no `/home` in `fileSystems`
- [x] Targeted `nix eval`/`nix derivation show` on the `boot.initrd.systemd.services.rollback-root` unit: confirmed ordering (`before sysroot.mount`, `requires`/`after` the root device unit, `after local-fs-pre.target`) and the generated rollback script text, and that both `btrfs-progs` and `findutils` are present in `boot.initrd.systemd.initrdBin`
- [x] Targeted `nix eval` check on `nixosConfigurations.legion-node1`: `persistence.enable = false`, no `rollback-root` unit, only the inert K3s directory declarations present
- [x] `bash -n modules/hosts/artemis/migrate-persist.sh` — syntax check after the `sync_dir` fix
- [x] Confirmed the `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` override doesn't regress a normal (non-root) `nix eval --impure` against this checkout
- [x] Real run against artemis: `just migrate-persist` + reboot succeeded, login worked (confirming ssh-host-key persistence + sops decryption); surfaced and fixed the root-owned `.config`/`.local`/`.cache` bug described above
- [x] Confirmed via `nix eval` that `hjem.linker` defaults to `smfh` (system-service linker path, not `systemd-tmpfiles`) and that `greetd.service` now has `after`/`wants` = `hjem-activate@aidanp.service`
- [x] Confirmed via `nix eval` that `.steam` no longer appears in `persistence.data.directories` and that `systemd.tmpfiles.rules` has no `.steam`-related entry (reverted after it broke real Steam launches on artemis)





