### PR TITLE
Unify Legion inventory and derive deployment targets

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -74,6 +74,14 @@ intentional and should not be "fixed" without explicit sign-off. See
   of implicit, hard-to-audit behavior this repo wants to avoid for a
   destructive-by-construction feature — see the `persistence.*` guardrail in
   `AGENTS.md` requiring explicit, documented data copies instead.
+- **Legion node details were duplicated across configuration, deployment,
+  TLS, and operator helpers.** Consolidated the inventory in
+  `modules/hosts/legion/default.nix`; NixOS configurations, deploy-rs nodes,
+  the bootstrap server address, node TLS SANs, `just deploy-legion`, and
+  `just legion-run` now derive from it. Evaluation also rejects multiple
+  bootstrap nodes or duplicate node IP addresses. Node 5's existing `.6`
+  private address remains unchanged pending confirmation against the live
+  host.
 
 ## Future Improvements
 
@@ -87,16 +95,7 @@ Listed in recommended implementation order.
   unrelated lock-file and package-hash updates out of CI-only changes so
   reviews remain focused.
 
-2. **Make the Legion node inventory the single source of truth.**
-  `modules/hosts/legion/default.nix` defines `legion-node5` and includes it
-  in `deploy.nodes`, but `just deploy-legion`, `just legion-run`, and the K3s
-  API TLS SAN list stop at node 4. Generate deployment targets, hostnames,
-  TLS SANs, and fleet operations from the same node attribute set. Add
-  assertions for unique IP addresses, exactly one bootstrap node, and a
-  deployment target for every Legion configuration. Confirm whether node
-  5's private address ending in `.6` is intentional before changing it.
-
-3. **Make remote-access and elevation policy explicit.** OpenSSH is enabled
+2. **Make remote-access and elevation policy explicit.** OpenSSH is enabled
   without an explicit authentication policy, while every wheel user gets
   passwordless `doas` with environment preservation on every host. At
   minimum, explicitly disable SSH password and keyboard-interactive
@@ -104,14 +103,14 @@ Listed in recommended implementation order.
   privileges; prefer a dedicated deployment user with narrowly scoped
   activation privileges over unrestricted passwordless root access.
 
-4. **Tighten the persistence option contract.** Remove the unused
+3. **Tighten the persistence option contract.** Remove the unused
   `persistence.volumeGroup` and `persistence.user` options, add types to the
   persistence path lists, require a non-empty `nukeRoot.device` whenever
   rollback is enabled, and assert that `nukeRoot.maxAge` is nonnegative.
   These checks should fail during evaluation rather than allowing a bad
   rollback configuration to reach the initrd.
 
-5. **Separate the login shell from the general-purpose toolbox.** The
+4. **Separate the login shell from the general-purpose toolbox.** The
   wrapped Fish login shell currently carries Cachix, devenv, and many CLI
   tools in `runtimePkgs`. Keep the shell wrapper small and move general
   tools into a system package module or the development shell. In
@@ -119,14 +118,14 @@ Listed in recommended implementation order.
   import-from-derivation step during evaluation, making evaluation from a
   non-`x86_64-linux` machine depend on a working Linux builder.
 
-6. **Add repository-policy checks.** Once CI is in place, add inexpensive
+5. **Add repository-policy checks.** Once CI is in place, add inexpensive
   evaluation checks for the invariants above: every applicable NixOS system
   has a deploy target, every Legion hostname is represented in generated
   SANs, exactly one K3s node bootstraps the cluster, and root rollback cannot
   be enabled without a device. Also enable treefmt's flake check instead of
   relying only on the development-shell hook.
 
-7. **Make the README useful for operating the flake.** Add a host and role
+6. **Make the README useful for operating the flake.** Add a host and role
   matrix, development-shell instructions, formatting and validation
   commands, safe deployment examples, links to `DESIGN.md` and this file,
   and a prominent reminder that Artemis persistence changes require running

--- a/justfile
+++ b/justfile
@@ -46,13 +46,7 @@ nh *args:
   NH_FLAKE={{justfile_directory()}} nh {{args}}
 
 deploy-legion *args:
-  @just deploy legion-node1 {{args}}
-  @just deploy legion-node2 {{args}}
-  @just deploy legion-node3 {{args}}
-  @just deploy legion-node4 {{args}}
+  @for node in $(nix eval --impure --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrNames nodes)'); do just deploy "$node" {{args}}; done
 
 legion-run *command:
-  ssh node1.jeiang.dev -- {{command}}
-  ssh node2.jeiang.dev -- {{command}}
-  ssh node3.jeiang.dev -- {{command}}
-  ssh node4.jeiang.dev -- {{command}}
+  @for host in $(nix eval --impure --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (_: node: node.hostname) nodes))'); do ssh "$host" -- {{command}}; done

--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -10,6 +10,63 @@
   podCIDRv4 = "10.42.0.0/16";
   serviceCIDRv4 = "10.43.0.0/16";
 
+  legionNodes = {
+    legion-node1 = {
+      bootstrap = true;
+      privateIPv4 = "172.17.0.1";
+      publicIPv4 = "178.156.226.145";
+      publicIPv6 = "2a01:4ff:f0:6b8e::1";
+    };
+
+    legion-node2 = {
+      privateIPv4 = "172.17.0.2";
+      publicIPv4 = "178.156.201.35";
+      publicIPv6 = "2a01:4ff:f0:a1ff::1";
+      agent = true;
+    };
+
+    legion-node3 = {
+      privateIPv4 = "172.17.0.3";
+      publicIPv4 = "178.156.186.147";
+      publicIPv6 = "2a01:4ff:f0:c52a::1";
+      agent = true;
+    };
+
+    legion-node4 = {
+      privateIPv4 = "172.17.0.4";
+      publicIPv4 = "178.156.191.180";
+      publicIPv6 = "2a01:4ff:f0:ca96::1";
+      agent = true;
+    };
+
+    legion-node5 = {
+      # Keep the gap at .5: this is the node's existing address, and changing
+      # cluster networking requires confirming the live host state first.
+      privateIPv4 = "172.17.0.6";
+      publicIPv4 = "178.156.253.100";
+      publicIPv6 = "2a01:4ff:f4:13f7::1";
+      agent = true;
+    };
+  };
+
+  bootstrapNodes = lib.filterAttrs (_: node: node.bootstrap or false) legionNodes;
+  nodeAddresses = lib.concatMap (node: [node.privateIPv4 node.publicIPv4 node.publicIPv6]) (builtins.attrValues legionNodes);
+
+  validatedLegionNodes = assert lib.assertMsg (builtins.length (builtins.attrNames bootstrapNodes) == 1)
+  "Legion inventory must define exactly one bootstrap node";
+  assert lib.assertMsg (builtins.length nodeAddresses == builtins.length (lib.unique nodeAddresses))
+  "Legion inventory must not reuse an IP address"; legionNodes;
+
+  bootstrapNode = builtins.head (builtins.attrValues (lib.filterAttrs (_: node: node.bootstrap or false) validatedLegionNodes));
+  nodeHostname = name: "${lib.removePrefix "legion-" name}.jeiang.dev";
+  apiTlsSans =
+    [
+      "pinard.co.tt"
+      "aidanpinard.co"
+      "jeiang.dev"
+    ]
+    ++ map nodeHostname (builtins.attrNames validatedLegionNodes);
+
   mkWan = {
     publicIPv4,
     publicIPv6,
@@ -90,7 +147,7 @@ in {
       };
 
       services.k3s = {
-        serverAddr = "https://172.17.0.1:6443";
+        serverAddr = "https://${bootstrapNode.privateIPv4}:6443";
 
         extraFlags = [
           "--flannel-iface=enp7s0"
@@ -120,35 +177,31 @@ in {
                   if (node.agent or false)
                   then "agent"
                   else "server";
-                extraFlags = lib.mkIf (!node.agent or false) [
-                  # Required before installing hcloud-cloud-controller-manager.
-                  "--disable-cloud-controller"
+                extraFlags = lib.mkIf (!node.agent or false) (
+                  [
+                    # Required before installing hcloud-cloud-controller-manager.
+                    "--disable-cloud-controller"
 
-                  # Required when using MetalLB instead of K3s ServiceLB.
-                  "--disable=servicelb"
+                    # Required when using MetalLB instead of K3s ServiceLB.
+                    "--disable=servicelb"
 
-                  # Avoid competing default storage classes when using Hetzner CSI.
-                  "--disable=local-storage"
+                    # Avoid competing default storage classes when using Hetzner CSI.
+                    "--disable=local-storage"
 
-                  # Dual-stack must be set when the cluster is first created.
-                  "--cluster-cidr=${podCIDRv4}"
-                  "--service-cidr=${serviceCIDRv4}"
-
-                  "--tls-san=pinard.co.tt"
-                  "--tls-san=aidanpinard.co"
-                  "--tls-san=jeiang.dev"
-                  "--tls-san=node1.jeiang.dev"
-                  "--tls-san=node2.jeiang.dev"
-                  "--tls-san=node3.jeiang.dev"
-                  "--tls-san=node4.jeiang.dev"
-
-                  "--kube-apiserver-arg=oidc-issuer-url=https://auth.jeiang.dev"
-                  "--kube-apiserver-arg=oidc-client-id=44213aa3-11eb-401d-922c-c7f81c3a9e37"
-                  "--kube-apiserver-arg=oidc-username-claim=preferred_username"
-                  "--kube-apiserver-arg=oidc-username-prefix=-"
-                  "--kube-apiserver-arg=oidc-groups-claim=groups"
-                  "--kube-apiserver-arg=oidc-groups-prefix="
-                ];
+                    # Dual-stack must be set when the cluster is first created.
+                    "--cluster-cidr=${podCIDRv4}"
+                    "--service-cidr=${serviceCIDRv4}"
+                  ]
+                  ++ map (san: "--tls-san=${san}") apiTlsSans
+                  ++ [
+                    "--kube-apiserver-arg=oidc-issuer-url=https://auth.jeiang.dev"
+                    "--kube-apiserver-arg=oidc-client-id=44213aa3-11eb-401d-922c-c7f81c3a9e37"
+                    "--kube-apiserver-arg=oidc-username-claim=preferred_username"
+                    "--kube-apiserver-arg=oidc-username-prefix=-"
+                    "--kube-apiserver-arg=oidc-groups-claim=groups"
+                    "--kube-apiserver-arg=oidc-groups-prefix="
+                  ]
+                );
               };
             }
 
@@ -161,56 +214,16 @@ in {
           ];
         };
     in
-      builtins.mapAttrs mkLegionSystem {
-        legion-node1 = {
-          bootstrap = true;
-          privateIPv4 = "172.17.0.1";
-          publicIPv4 = "178.156.226.145";
-          publicIPv6 = "2a01:4ff:f0:6b8e::1";
-        };
-
-        legion-node2 = {
-          privateIPv4 = "172.17.0.2";
-          publicIPv4 = "178.156.201.35";
-          publicIPv6 = "2a01:4ff:f0:a1ff::1";
-          agent = true;
-        };
-
-        legion-node3 = {
-          privateIPv4 = "172.17.0.3";
-          publicIPv4 = "178.156.186.147";
-          publicIPv6 = "2a01:4ff:f0:c52a::1";
-          agent = true;
-        };
-
-        legion-node4 = {
-          privateIPv4 = "172.17.0.4";
-          publicIPv4 = "178.156.191.180";
-          publicIPv6 = "2a01:4ff:f0:ca96::1";
-          agent = true;
-        };
-
-        legion-node5 = {
-          privateIPv4 = "172.17.0.6";
-          publicIPv4 = "178.156.253.100";
-          publicIPv6 = "2a01:4ff:f4:13f7::1";
-          agent = true;
-        };
-      };
-    deploy.nodes = let
-      mkDeploy = name: {hostname}: {
-        inherit hostname;
+      builtins.mapAttrs mkLegionSystem validatedLegionNodes;
+    deploy.nodes =
+      builtins.mapAttrs (name: _: {
+        hostname = nodeHostname name;
         sudo = "doas -u";
         profiles.system = {
           user = "root";
           path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.${name};
         };
-      };
-      nodes = builtins.listToAttrs (map (node: {
-        name = "legion-${node}";
-        value = {hostname = "${node}.jeiang.dev";};
-      }) ["node1" "node2" "node3" "node4" "node5"]);
-    in
-      builtins.mapAttrs mkDeploy nodes;
+      })
+      validatedLegionNodes;
   };
 }


### PR DESCRIPTION
## Summary
- Consolidate Legion node inventory into `modules/hosts/legion/default.nix` as the single source of truth.
- Derive K3s bootstrap address, TLS SANs, deploy-rs nodes, and `just` helpers from the shared inventory.
- Add evaluation-time assertions for exactly one bootstrap node and unique IP addresses.
- Keep node 5's existing `.6` private address unchanged pending live host confirmation.

## Testing
- Not run (not requested)