### PR TITLE
ci: limit matrix parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
     needs: discover
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         check: ${{ fromJson(needs.discover.outputs.checks) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

Limits the CI build matrix to two concurrent jobs per workflow run.

## Why

The matrix currently starts every discovered check at once. Capping it reduces concurrent GitHub runner and Attic cache load while retaining matrix coverage.

## Validation

- YAML parsed successfully
- `git diff --check`
- Pre-commit hooks: editorconfig-checker and treefmt passed
- `just fmt` and `just check` could not run because the local Lix daemon socket is unavailable
