### PR TITLE
fix(persistence): validate persistence options

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -74,6 +74,13 @@ intentional and should not be "fixed" without explicit sign-off. See
   of implicit, hard-to-audit behavior this repo wants to avoid for a
   destructive-by-construction feature — see the `persistence.*` guardrail in
   `AGENTS.md` requiring explicit, documented data copies instead.
+- **Persistence options accepted invalid values until impermanence consumed
+  them.** Removed the unused `persistence.volumeGroup` and
+  `persistence.user` options, typed persistence entry lists as strings or
+  attribute sets, and restricted `nukeRoot.maxAge` to nonnegative integers.
+  Root rollback now requires persistence to be enabled and rejects empty
+  device or subvolume values during NixOS evaluation. Existing Artemis
+  persistence entries and rollback behavior remain unchanged.
 
 ## Future Improvements
 
@@ -104,14 +111,7 @@ Listed in recommended implementation order.
   privileges; prefer a dedicated deployment user with narrowly scoped
   activation privileges over unrestricted passwordless root access.
 
-4. **Tighten the persistence option contract.** Remove the unused
-  `persistence.volumeGroup` and `persistence.user` options, add types to the
-  persistence path lists, require a non-empty `nukeRoot.device` whenever
-  rollback is enabled, and assert that `nukeRoot.maxAge` is nonnegative.
-  These checks should fail during evaluation rather than allowing a bad
-  rollback configuration to reach the initrd.
-
-5. **Separate the login shell from the general-purpose toolbox.** The
+4. **Separate the login shell from the general-purpose toolbox.** The
   wrapped Fish login shell currently carries Cachix, devenv, and many CLI
   tools in `runtimePkgs`. Keep the shell wrapper small and move general
   tools into a system package module or the development shell. In
@@ -119,14 +119,14 @@ Listed in recommended implementation order.
   import-from-derivation step during evaluation, making evaluation from a
   non-`x86_64-linux` machine depend on a working Linux builder.
 
-6. **Add repository-policy checks.** Once CI is in place, add inexpensive
+5. **Add repository-policy checks.** Once CI is in place, add inexpensive
   evaluation checks for the invariants above: every applicable NixOS system
   has a deploy target, every Legion hostname is represented in generated
   SANs, exactly one K3s node bootstraps the cluster, and root rollback cannot
   be enabled without a device. Also enable treefmt's flake check instead of
   relying only on the development-shell hook.
 
-7. **Make the README useful for operating the flake.** Add a host and role
+6. **Make the README useful for operating the flake.** Add a host and role
   matrix, development-shell instructions, formatting and validation
   commands, safe deployment examples, links to `DESIGN.md` and this file,
   and a prominent reminder that Artemis persistence changes require running

--- a/modules/nixos/base/persistence.nix
+++ b/modules/nixos/base/persistence.nix
@@ -1,10 +1,23 @@
 {
-  flake.nixosModules.base = {lib, ...}: {
+  flake.nixosModules.base = {
+    config,
+    lib,
+    ...
+  }: let
+    cfg = config.persistence;
+    persistenceEntryType = lib.types.either lib.types.str (lib.types.attrsOf lib.types.anything);
+    persistenceListOption = description:
+      lib.mkOption {
+        type = lib.types.listOf persistenceEntryType;
+        default = [];
+        description = "${description} Entries may be strings or impermanence-compatible attribute sets.";
+      };
+  in {
     options.persistence = {
-      enable = lib.mkEnableOption "enable persistence";
+      enable = lib.mkEnableOption "persistent storage mounts";
 
       nukeRoot = {
-        enable = lib.mkEnableOption "roll the btrfs root subvolume back to an empty subvolume on every boot";
+        enable = lib.mkEnableOption "rolling the btrfs root subvolume back to an empty subvolume on every boot";
 
         device = lib.mkOption {
           type = lib.types.str;
@@ -28,7 +41,7 @@
         };
 
         maxAge = lib.mkOption {
-          type = lib.types.int;
+          type = lib.types.ints.unsigned;
           default = 30;
           description = ''
             Age in days after which old roots under `/old_roots` on the
@@ -37,61 +50,29 @@
         };
       };
 
-      volumeGroup = lib.mkOption {
-        default = "btrfs_vg";
-        description = ''
-          Btrfs volume group name
-        '';
-      };
+      directories = persistenceListOption "System directories to persist under `/persist`.";
+      files = persistenceListOption "System files to persist under `/persist`.";
 
-      user = lib.mkOption {
-        default = "username";
-        description = ''
-          Main user
-        '';
-      };
+      data.directories = persistenceListOption "User data directories to persist under `/persist/data`.";
+      data.files = persistenceListOption "User data files to persist under `/persist/data`.";
 
-      directories = lib.mkOption {
-        default = [];
-        description = ''
-          directories to persist
-        '';
-      };
-
-      files = lib.mkOption {
-        default = [];
-        description = ''
-          files to persist
-        '';
-      };
-
-      data.directories = lib.mkOption {
-        default = [];
-        description = ''
-          directories to persist
-        '';
-      };
-
-      data.files = lib.mkOption {
-        default = [];
-        description = ''
-          files to persist
-        '';
-      };
-
-      cache.directories = lib.mkOption {
-        default = [];
-        description = ''
-          directories to persist
-        '';
-      };
-
-      cache.files = lib.mkOption {
-        default = [];
-        description = ''
-          files to persist
-        '';
-      };
+      cache.directories = persistenceListOption "User cache directories to persist under `/persist/cache`.";
+      cache.files = persistenceListOption "User cache files to persist under `/persist/cache`.";
     };
+
+    config.assertions = [
+      {
+        assertion = !cfg.nukeRoot.enable || cfg.enable;
+        message = "persistence.nukeRoot.enable requires persistence.enable";
+      }
+      {
+        assertion = !cfg.nukeRoot.enable || cfg.nukeRoot.device != "";
+        message = "persistence.nukeRoot.device must be set when root rollback is enabled";
+      }
+      {
+        assertion = !cfg.nukeRoot.enable || cfg.nukeRoot.subvolume != "";
+        message = "persistence.nukeRoot.subvolume must be set when root rollback is enabled";
+      }
+    ];
   };
 }


### PR DESCRIPTION
## Summary

- type persistence entry lists as strings or impermanence-compatible attribute sets
- remove the unused `persistence.volumeGroup` and `persistence.user` options
- restrict `persistence.nukeRoot.maxAge` to nonnegative integers
- require persistence to be enabled and require nonempty device and subvolume values when root rollback is enabled
- record the completed improvement in `docs/IMPROVEMENTS.md`

## Why

The local persistence options accepted arbitrary values and allowed incomplete root rollback settings to survive until later NixOS or initrd evaluation. This moves those failures to the module boundary while preserving the upstream impermanence entry format.

## Impact

Existing Artemis persistence paths, the rollback script, disk layout, and runtime behavior are unchanged. Invalid future configurations now fail during evaluation.

## Validation

- `just fmt`
- commit hooks: EditorConfig, Statix, and treefmt
- evaluated the current Artemis persistence configuration
- verified negative ages and invalid persistence entries fail type checking
- verified incomplete rollback configurations trigger the new assertions
- `just check` was attempted but remains blocked by existing aarch64-darwin evaluation failures for Linux-only packages and the Cachix IFD
