### PR TITLE
Clarify remote access and deployment identity policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,16 @@
+# System Access
+
+Terms for identities that administer and deploy the systems managed by this
+flake.
+
+## Language
+
+**Human Administrator**:
+A person who performs interactive system administration and recovery.
+_Avoid_: Deployment identity, automation user
+
+**Deployment Identity**:
+A privileged, non-human identity used only by automation to deploy system
+configurations. Its credentials grant administrative control of deployment
+targets.
+_Avoid_: Human administrator, personal account

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -89,6 +89,16 @@ intentional and should not be "fixed" without explicit sign-off. See
   bootstrap nodes or duplicate node IP addresses. Node 5's existing `.6`
   private address remains unchanged pending confirmation against the live
   host.
+- **Remote access and elevation policy were implicit and shared across host
+  roles.** SSH now explicitly disables password and keyboard-interactive
+  authentication and direct root login on every host. Artemis uses
+  password-required `doas` with credential caching and a sanitized
+  environment. Legion deployments connect through a dedicated, restricted-key
+  `deploy` account whose passwordless sudo rule is limited to deploy-rs
+  activation executables; wheel users retain password-protected sudo for
+  administrative recovery. The deployment account is intentionally a Nix
+  trusted user and therefore root-equivalent despite the narrower sudo rule;
+  see [ADR 0001](adr/0001-treat-deployment-identity-as-privileged.md).
 
 ## Future Improvements
 
@@ -102,15 +112,7 @@ Listed in recommended implementation order.
   unrelated lock-file and package-hash updates out of CI-only changes so
   reviews remain focused.
 
-2. **Make remote-access and elevation policy explicit.** OpenSSH is enabled
-  without an explicit authentication policy, while every wheel user gets
-  passwordless `doas` with environment preservation on every host. At
-  minimum, explicitly disable SSH password and keyboard-interactive
-  authentication. Separate workstation elevation from server deployment
-  privileges; prefer a dedicated deployment user with narrowly scoped
-  activation privileges over unrestricted passwordless root access.
-
-3. **Separate the login shell from the general-purpose toolbox.** The
+2. **Separate the login shell from the general-purpose toolbox.** The
   wrapped Fish login shell currently carries Cachix, devenv, and many CLI
   tools in `runtimePkgs`. Keep the shell wrapper small and move general
   tools into a system package module or the development shell. In
@@ -118,14 +120,14 @@ Listed in recommended implementation order.
   import-from-derivation step during evaluation, making evaluation from a
   non-`x86_64-linux` machine depend on a working Linux builder.
 
-4. **Add repository-policy checks.** Once CI is in place, add inexpensive
+3. **Add repository-policy checks.** Once CI is in place, add inexpensive
   evaluation checks for the invariants above: every applicable NixOS system
   has a deploy target, every Legion hostname is represented in generated
   SANs, exactly one K3s node bootstraps the cluster, and root rollback cannot
   be enabled without a device. Also enable treefmt's flake check instead of
   relying only on the development-shell hook.
 
-5. **Make the README useful for operating the flake.** Add a host and role
+4. **Make the README useful for operating the flake.** Add a host and role
   matrix, development-shell instructions, formatting and validation
   commands, safe deployment examples, links to `DESIGN.md` and this file,
   and a prominent reminder that Artemis persistence changes require running

--- a/docs/adr/0001-treat-deployment-identity-as-privileged.md
+++ b/docs/adr/0001-treat-deployment-identity-as-privileged.md
@@ -1,0 +1,7 @@
+# Treat the deployment identity as privileged
+
+The Deployment Identity is a Nix trusted user so deploy-rs can copy unsigned
+closures, which makes it effectively root-equivalent. Keep sudo restricted to
+deploy-rs activation executables as defense-in-depth and for audit clarity, but
+do not treat that rule as containment for a compromised deployment credential;
+avoiding Nix trust would require a separate signed-closure delivery design.

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -181,9 +181,6 @@
       };
       nixpkgs.hostPlatform = "x86_64-linux";
       system.stateVersion = "25.05";
-      users.users.root.openssh.authorizedKeys.keys = [
-        "AAAAC3NzaC1lZDI1NTE5AAAAIDX/1mgkG5030b8C3eAZN2vBcoYvS9d+/OTtRf0f6XJJ"
-      ];
     };
   };
 }

--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -95,15 +95,44 @@
   };
 in {
   flake = {
-    nixosModules.legionConfiguration = {
+    nixosModules.legionConfiguration = {pkgs, ...}: {
       imports = [
         self.nixosModules.base
         self.nixosModules.sharedConfiguration
         self.nixosModules.sops
         self.nixosModules.legionHardware
-        self.nixosModules.doas
         self.nixosModules.k3s
         self.diskoConfigurations.legion
+      ];
+
+      users = {
+        groups.deploy = {};
+        users.deploy = {
+          isSystemUser = true;
+          group = "deploy";
+          home = "/var/empty";
+          createHome = false;
+          hashedPassword = "!";
+          shell = pkgs.bashInteractive;
+          openssh.authorizedKeys.keys = [
+            "restrict ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEDR/RgCI/ULKL6ywYbmeqvU5BfjpmMnOieuQ66XlX+ legion-deploy"
+          ];
+        };
+      };
+
+      nix.settings.trusted-users = ["deploy"];
+
+      security.sudo.extraRules = [
+        {
+          users = ["deploy"];
+          runAs = "root";
+          commands = [
+            {
+              command = "/nix/store/*/activate-rs";
+              options = ["NOPASSWD"];
+            }
+          ];
+        }
       ];
 
       boot = {
@@ -218,7 +247,10 @@ in {
     deploy.nodes =
       builtins.mapAttrs (name: _: {
         hostname = nodeHostname name;
-        sudo = "doas -u";
+        # The first activation removes doas, so disable its doas-based waiter:
+        # deploy .#legion-nodeN --ssh-user aidanp --sudo='doas -u' --magic-rollback=false -- --impure
+        sshUser = "deploy";
+        sudo = "sudo -u";
         profiles.system = {
           user = "root";
           path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.${name};

--- a/modules/nixos/security.nix
+++ b/modules/nixos/security.nix
@@ -7,8 +7,7 @@
         extraRules = [
           {
             groups = ["wheel"];
-            noPass = true;
-            keepEnv = true;
+            persist = true;
           }
         ];
       };

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -28,8 +28,14 @@
     sops.secrets."passwords/aidanp".neededForUsers = true;
     sops.secrets."passwords/root".neededForUsers = true;
     zramSwap.enable = true;
-    services.openssh.enable = true;
-    security.sudo.wheelNeedsPassword = false;
+    services.openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = "no";
+      };
+    };
     environment.systemPackages = [
       self.packages.${pkgs.stdenv.hostPlatform.system}.git
     ];

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,2 @@
+disabled = []
+ignore = [".direnv", ".claude"]


### PR DESCRIPTION
## Summary
- Make SSH policy explicit by disabling password auth, keyboard-interactive auth, and direct root login on all hosts.
- Split elevation policy by role: Artemis keeps password-gated `doas` with cached credentials, while Legion gets a dedicated `deploy` account for deploy-rs activation.
- Treat the deployment identity as privileged in docs, and remove the old root SSH key from Artemis.
- Tighten shared sudo defaults to preserve wheel credentials instead of granting passwordless elevation everywhere.
- Add `statix.toml` ignores for local workspace directories.

## Testing
- Not run (not requested)