### PR TITLE
fix(environment): avoid Cachix IFD in toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Move the host toolbox out of the wrapped Fish shell and use Cachix's pinned binary package to avoid IFD evaluation.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -112,22 +112,14 @@ Listed in recommended implementation order.
   unrelated lock-file and package-hash updates out of CI-only changes so
   reviews remain focused.
 
-2. **Separate the login shell from the general-purpose toolbox.** The
-  wrapped Fish login shell currently carries Cachix, devenv, and many CLI
-  tools in `runtimePkgs`. Keep the shell wrapper small and move general
-  tools into a system package module or the development shell. In
-  particular, `cachix` pulls in a `cabal2nix`-based
-  import-from-derivation step during evaluation, making evaluation from a
-  non-`x86_64-linux` machine depend on a working Linux builder.
-
-3. **Add repository-policy checks.** Once CI is in place, add inexpensive
+2. **Add repository-policy checks.** Once CI is in place, add inexpensive
   evaluation checks for the invariants above: every applicable NixOS system
   has a deploy target, every Legion hostname is represented in generated
   SANs, exactly one K3s node bootstraps the cluster, and root rollback cannot
   be enabled without a device. Also enable treefmt's flake check instead of
   relying only on the development-shell hook.
 
-4. **Make the README useful for operating the flake.** Add a host and role
+3. **Make the README useful for operating the flake.** Add a host and role
   matrix, development-shell instructions, formatting and validation
   commands, safe deployment examples, links to `DESIGN.md` and this file,
   and a prominent reminder that Artemis persistence changes require running

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -7,6 +7,7 @@
     imports = [
       self.nixosModules.hjem
       self.nixosModules.nix
+      self.nixosModules.toolbox
     ];
     users = {
       mutableUsers = false;
@@ -36,8 +37,5 @@
         PermitRootLogin = "no";
       };
     };
-    environment.systemPackages = [
-      self.packages.${pkgs.stdenv.hostPlatform.system}.git
-    ];
   };
 }

--- a/modules/nixos/toolbox.nix
+++ b/modules/nixos/toolbox.nix
@@ -1,0 +1,43 @@
+{self, ...}: {
+  flake.nixosModules.toolbox = {
+    pkgs,
+    lib,
+    ...
+  }: {
+    environment.systemPackages = with pkgs; [
+      self.packages.${pkgs.stdenv.hostPlatform.system}.git
+      self.packages.${pkgs.stdenv.hostPlatform.system}.difft
+      self.packages.${pkgs.stdenv.hostPlatform.system}.helix
+      self.packages.${pkgs.stdenv.hostPlatform.system}.cachix
+      fd
+      dig
+      glow
+      bandwhich
+      bingrep
+      choose
+      (devenv.override {
+        cachix = self.packages.${pkgs.stdenv.hostPlatform.system}.cachix;
+      })
+      duf
+      erdtree
+      file
+      hyperfine
+      libtree
+      (ouch.override {enableUnfree = true;})
+      parallel
+      procs
+      ripgrep
+      rnr
+      sad
+      tdf
+      (writeShellApplication {
+        name = "trash";
+        text = ''
+          ${lib.getExe gomi} "$@"
+        '';
+      })
+      tokei
+      xh
+    ];
+  };
+}

--- a/modules/packages/cachix.nix
+++ b/modules/packages/cachix.nix
@@ -1,0 +1,17 @@
+{
+  perSystem = {pkgs, ...}: let
+    paths = {
+      x86_64-linux = "/nix/store/5r4nmn8plfw8fa11rb4xjcv3fmw6vlgm-cachix-1.11.1-bin";
+      x86_64-darwin = "/nix/store/v70b0nphyrizc3vfkjgnfxmwy7r451bw-cachix-1.11.1-bin";
+      aarch64-darwin = "/nix/store/cg4cq7w8iiwh1az929w9d58n2n207ilx-cachix-1.11.1-bin";
+      aarch64-linux = "/nix/store/w0f7i0cfn3gcfyl6dd0x7x4i8yagnad5-cachix-1.11.1-bin";
+    };
+  in {
+    packages.cachix =
+      pkgs.runCommand "cachix-1.11.1" {
+        src = builtins.storePath paths.${pkgs.stdenv.hostPlatform.system};
+      } ''
+        ln -s "$src" "$out"
+      '';
+  };
+}

--- a/modules/packages/environment.nix
+++ b/modules/packages/environment.nix
@@ -3,7 +3,6 @@
     pkgs,
     lib,
     self',
-    inputs',
     ...
   }: {
     packages = {
@@ -12,39 +11,6 @@
         package = self'.packages.fish;
         # needed for nixos to recognize this as a shell
         passthru.shellPath = "/bin/fish";
-        runtimePkgs = with pkgs; [
-          self'.packages.git
-          self'.packages.difft
-          self'.packages.helix
-          fd
-          dig
-          glow
-          bandwhich
-          bingrep
-          cachix
-          choose
-          inputs'.devenv.packages.default
-          duf
-          erdtree
-          file
-          hyperfine
-          libtree
-          (ouch.override {enableUnfree = true;})
-          parallel
-          procs
-          ripgrep
-          rnr
-          sad
-          tdf
-          (pkgs.writeShellApplication {
-            name = "trash";
-            text = ''
-              ${lib.getExe gomi} "$@"
-            '';
-          })
-          tokei
-          xh
-        ];
         env = {
           EDITOR = lib.getExe self'.packages.helix;
         };


### PR DESCRIPTION
## Summary

- Move the general CLI toolbox out of the wrapped Fish login shell and into shared NixOS system packages.
- Add a hash-pinned Cachix binary package and override devenv to use it.
- Remove the completed improvement item and add an Unreleased changelog entry.

## Root cause

Nixpkgs Cachix evaluates a `cabal2nix` import-from-derivation. The wrapped Fish package and devenv's embedded Cachix dependency made Darwin flake evaluation require an x86_64 Linux builder.

## Validation

- `just fmt`
- Repository pre-commit hooks: editorconfig-checker, statix, treefmt
- `nix eval --impure --system aarch64-darwin --raw .#cachix.name`
- Darwin `deploy-schema` and `deploy-activate` derivation evaluations

`just check` now evaluates both deploy checks successfully. It still reports existing unsupported-Darwin failures for DMS, dsearch, Ghostty, Nitch, Mangohud, and Hyprpaper.
