### PR TITLE
feat(nix): add attic.jeiang.dev substituter for CI-built closures

### DIFF
--- a/modules/nixos/nix.nix
+++ b/modules/nixos/nix.nix
@@ -61,15 +61,21 @@
         ];
         flake-registry = "/etc/nix/registry.json";
 
+        # attic.jeiang.dev is self-hosted; don't let a cache outage stall deploys
+        connect-timeout = 5;
+        fallback = true;
+
         # for direnv GC roots
         keep-derivations = true;
         keep-outputs = true;
 
         substituters = [
+          "https://attic.jeiang.dev/default"
           "https://helix.cachix.org"
           "https://hyprland.cachix.org"
         ];
         trusted-public-keys = [
+          "default:Xaqeg5b1ctNwH4sEWG+nt1kSpGPpFG0zivJUbZyCfdM="
           "helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs="
           "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
         ];


### PR DESCRIPTION
## Summary
- Add `https://attic.jeiang.dev/default` and its public key to the shared `nix.settings` in `modules/nixos/nix.nix`, so deploy-rs deploys substitute the exact system closures CI already pushes to the Attic cache instead of rebuilding them on the target. Pulls are anonymous (public cache), so no netrc/token is needed.
- Add `connect-timeout = 5` and `fallback = true` so an outage of the self-hosted cache degrades to building locally instead of stalling deploys for minutes on the default connect timeout.

## Validation
- `just fmt` passes (statix + treefmt clean; also enforced by pre-commit on this commit).
- `nix flake check --no-build` exits 0 (evaluates every check including all six toplevels). The full `just check` build isn't possible on the authoring machine (aarch64-darwin, no x86_64-linux builder) — CI will run the real builds.
- Targeted eval on `artemis` and `legion-node1` confirms the merged settings: Attic cache in `substituters`, key in `trusted-public-keys`, `connect-timeout = 5`, `fallback = true`.

## Rollout note
Substituter settings take effect only after activation, so the first deploy of this change still fetches the old way; subsequent deploys will pull from the Attic cache. Verify on a host with `nix config show substituters` and watch a later deploy for `copying path ... from 'https://attic.jeiang.dev/default'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)