### PR TITLE
chore(justfile): drop --impure from deploy/eval recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ clean-deploy system address *args:
   nix run github:nix-community/nixos-anywhere -- --generate-hardware-config nixos-facter ./modules/hosts/{{system}}/facter.json  --flake .#{{system}} --target-host root@{{address}} {{args}}
 
 deploy system *args:
-  deploy .#{{system}} {{args}} -- --impure
+  deploy .#{{system}} {{args}}
 
 # Run this after editing .sops.yaml
 sops-updatekeys:
@@ -46,7 +46,7 @@ nh *args:
   NH_FLAKE={{justfile_directory()}} nh {{args}}
 
 deploy-legion *args:
-  @for node in $(nix eval --impure --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrNames nodes)'); do just deploy "$node" {{args}}; done
+  @for node in $(nix eval --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrNames nodes)'); do just deploy "$node" {{args}}; done
 
 legion-run *command:
-  @for host in $(nix eval --impure --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (_: node: node.hostname) nodes))'); do ssh "$host" -- {{command}}; done
+  @for host in $(nix eval --raw '.#deploy.nodes' --apply 'nodes: builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (_: node: node.hostname) nodes))'); do ssh "$host" -- {{command}}; done


### PR DESCRIPTION
## Summary
- Remove `--impure` from the `deploy`, `deploy-legion`, and `legion-run` recipes — pure evaluation works since the `builtins.storePath` cachix hack was removed in #26. Deploy verified locally without the flag.
- `just check` keeps `--impure`: `nix flake check` evaluates the devenv devshell, which requires it (reads $PWD at eval time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)