### PR TITLE
fix(deploy): allow passwordless rm of the magic-rollback canary

### DIFF
--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -233,6 +233,16 @@ in {
               command = "/nix/store/*/activate-rs";
               options = ["NOPASSWD"];
             }
+            # Magic rollback: after activation succeeds, deploy-rs confirms
+            # over a second SSH session with `sudo -u root rm
+            # /tmp/deploy-rs-canary-<hash>` (src/deploy.rs confirm_profile).
+            # Bare `rm` resolves to the system path for the deploy user, so
+            # match it there; without this rule sudo prompts for a password,
+            # the confirmation times out, and every deploy rolls back.
+            {
+              command = "/run/current-system/sw/bin/rm /tmp/deploy-rs-canary-*";
+              options = ["NOPASSWD"];
+            }
           ];
         }
       ];


### PR DESCRIPTION
## Summary
- deploy-rs confirms a deployment by running `sudo -u root rm /tmp/deploy-rs-canary-<hash>` over a second SSH session (`confirm_profile` in `src/deploy.rs`), but the `deploy` user's NOPASSWD sudoers rule only covered `/nix/store/*/activate-rs`. sudo prompted for a password (no TTY), the confirmation timed out, and every magic-rollback deploy rolled back to the previous generation.
- Adds a second NOPASSWD command to the same rule: `/run/current-system/sw/bin/rm /tmp/deploy-rs-canary-*` (bare `rm` resolves to the system path for the deploy user). Not a privilege escalation in practice: `deploy` is a Nix trusted user that can already run arbitrary `/nix/store/*/activate-rs`.

## Validation
- Pure `nix eval` of `nixosConfigurations.legion-node4.config.security.sudo.extraRules` renders both commands.
- `visudo -c` parses the generated rule line.
- Pre-commit hooks (editorconfig-checker, statix, treefmt) passed.

## Rollout
No chicken-and-egg: activation writes the new sudoers into /etc before the confirmation `rm` runs, so the first deploy carrying this rule should confirm successfully with magic rollback still enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)