### PR TITLE
fix(edge): serve NetBird dashboard deep links via {path}.html

### DIFF
--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -273,9 +273,25 @@
               }
             }
 
+            # The dashboard (netbird-dashboard 2.x) is a Next.js `output:
+            # "export"` static build: every route is pre-rendered to its own
+            # top-level file (`networks.html`, `peers.html`, ...), not a
+            # single-page app served from one index.html. So a direct hit on
+            # `/networks` must resolve to `networks.html`; the `{path}.html`
+            # candidate is what does that. Without it, `try_files` skips the
+            # `networks/` dir (RSC `.txt` payloads, no HTML index) and falls
+            # straight through to `/index.html` -- serving the home page's
+            # document at the /networks URL, which makes Next's App Router
+            # hydrate with the wrong route tree and hard-reload forever (the
+            # deep-link "loading loop"; client-side nav works because it
+            # fetches the `.txt` RSC payloads directly). This mirrors
+            # NetBird's own reference nginx config's
+            # `try_files $uri $uri.html $uri/ =404` (dashboard
+            # docker/default.conf); the final `/index.html` keeps the
+            # SPA-style fallback for anything unmatched.
             handle {
               ${appsecLine}root * ${netbirdDashboard}
-              try_files {path} /index.html
+              try_files {path} {path}.html {path}/index.html /index.html
               file_server
             }
           }


### PR DESCRIPTION
## Problem

Navigating directly to `netbird.jeiang.dev/networks` (or any dashboard route) gets stuck in an infinite loading loop. Landing on the root and clicking through works fine.

## Root cause

`netbird-dashboard` 2.90.3 is a **Next.js `output: "export"` static build** — every route is pre-rendered to its own top-level file (`networks.html`, `peers.html`, `settings.html`, …), not a single-page app served from one `index.html`.

The edge Caddy fallback served it SPA-style:

```caddy
try_files {path} /index.html
```

For `/networks`, `try_files` looks for a file literally named `networks` (only a `networks/` directory exists, holding RSC `.txt` payloads with no HTML index), finds nothing servable, and falls back to the root `/index.html` — handing the browser the **home page's** document at the `/networks` URL. Next's App Router then hydrates with the wrong route tree and hard-reloads forever.

Client-side navigation from the root is unaffected because it fetches the `.txt` RSC payloads directly, never a server document.

## Fix

Add the `.html` candidate (and the directory-index candidate) before the SPA fallback, mirroring NetBird's own reference nginx config (`try_files $uri $uri.html $uri/ =404`, from the dashboard's `docker/default.conf`):

```caddy
try_files {path} {path}.html {path}/index.html /index.html
```

Now `/networks` resolves to `networks.html` and serves the correct pre-rendered page.

## Validation

- Confirmed the built dashboard emits per-route `*.html` files (`networks.html`, `peers.html`, …).
- Confirmed against NetBird's shipped `docker/default.conf` nginx config.
- `legion-node1` toplevel instantiates cleanly; pre-commit (editorconfig/statix/treefmt) passes. Full `caddy validate` couldn't run locally (needs an `x86_64-linux` builder) — worth confirming on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)