### PR TITLE
feat(blocky): add Cloudflare and Quad9 plain-IP upstreams

### DIFF
--- a/modules/nixos/blocky.nix
+++ b/modules/nixos/blocky.nix
@@ -29,8 +29,11 @@ _: {
         };
         upstreams.groups.default = [
           "1.1.1.1"
+          "1.0.0.1"
           "8.8.8.8"
           "8.8.4.4"
+          "9.9.9.9"
+          "149.112.112.112"
           "tcp-tls:one.one.one.one:853"
           "tcp-tls:dns.google:853"
           "tcp-tls:dns.quad9.net:853"


### PR DESCRIPTION
## Summary
- Cloudflare only had one anycast IP (1.1.1.1) upstream and Quad9 had none (TLS-hostname only), while Google had two plain IPs. Add `1.0.0.1` for Cloudflare and `9.9.9.9`/`149.112.112.112` for Quad9 so all three providers have matching plain-IP + TLS coverage.

## Test plan
- [x] `nix eval .#nixosConfigurations.legion-node2.config.services.blocky.settings.upstreams.groups.default` shows the new IPs
- [x] `nix fmt` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)