### PR TITLE
fix(ci): sign flake-lock update commits with a dedicated bot key

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -163,6 +163,13 @@ jobs:
       # FLAKE_LOCK_PAT must be a PAT (fine-grained: Contents + Pull requests
       # read/write on this repo, or classic with the `repo` scope) stored as
       # a repo secret.
+      #
+      # main requires signed commits, so the commit this action makes also
+      # needs a verifiable signature -- sign-commits pulls in a dedicated
+      # bot GPG key (see AGENTS.md for the secret name and setup steps) and
+      # signs with it; the commit's author/committer identity then comes
+      # from that key's UID, not from git-author-*/git-committer-* (unused
+      # here since those inputs only apply when sign-commits is false).
       - name: Update selected inputs and open PR
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
@@ -171,3 +178,5 @@ jobs:
           branch: update-flake-lock/tracked-inputs
           commit-msg: "chore(flake): update flake inputs"
           pr-title: "chore(flake): update flake inputs"
+          sign-commits: true
+          gpg-private-key: ${{ secrets.FLAKE_LOCK_GPG_PRIVATE_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ This repo manages live systems, disks, cluster membership, and secrets. Treat op
 ## CI Secrets
 
 - `FLAKE_LOCK_PAT`: fine-grained PAT used by `.github/workflows/update-flake-inputs.yml` so its flake-lock update PRs trigger CI (the default `GITHUB_TOKEN` cannot trigger further workflow runs). **Expires 2027-07-22** — rotate it before then, or the workflow's PRs will stop getting CI runs with no obvious error.
+- `FLAKE_LOCK_GPG_PRIVATE_KEY`: ASCII-armored private key for a dedicated `flake-lock-bot` GPG key, used by the same workflow to sign its commits (`main` requires signed commits, so unsigned bot commits can't be merged). The key's UID email must be a verified email on the account holding `FLAKE_LOCK_PAT` (this repo uses that account's GitHub-provided `<id>+<login>@users.noreply.github.com` address, which is verified automatically with no separate confirmation step), and its public half must be added as a GPG key on that same account.
 
 ## Common Commands
 


### PR DESCRIPTION
## Summary
- `main` requires signed commits. `update-flake-lock` (in `update-flake-inputs.yml`) was pushing commits authenticated with `FLAKE_LOCK_PAT` but not GPG-signed, so PR #43 (its first automated run) is blocked from merging with "Commits must have verified signatures."
- Enables the action's `sign-commits` path, backed by a new `FLAKE_LOCK_GPG_PRIVATE_KEY` repo secret holding a dedicated bot signing key. Setup steps and rationale are documented in `AGENTS.md` under CI Secrets.

## Test plan
- [x] YAML validated, pre-commit hooks pass.
- [ ] Generate the bot GPG key, add its public half to GitHub, store the private half as `FLAKE_LOCK_GPG_PRIVATE_KEY` (see AGENTS.md).
- [ ] Merge this PR, close/delete PR #43 and its branch, then re-run `update-flake-inputs.yml` via `workflow_dispatch` and confirm the new PR's commit shows as Verified and CI runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)