### PR TITLE
fix(hermes): make activation survive first deploy on fresh volume

### DIFF
--- a/docs/runbooks/hermes-activation.md
+++ b/docs/runbooks/hermes-activation.md
@@ -56,13 +56,14 @@ Done when: main contains the enabled entry.
 3. If hermes-agent logs an auth failure, authenticate the seeded Codex CLI
   as the `hermes` user and confirm `gpt-5.6-terra` is accepted.
 4. Create the worktrees as `hermes`, cloned from the local mirrors (Hermes
-  owns them and never holds a GitHub credential):
+  owns them and never holds a GitHub credential). `HOME=/mnt/hermes` makes git
+  read the hermes-owned `.gitconfig` that hermes-state-init writes, which
+  marks the publisher-owned mirrors as safe — no `git config --global` needed
+  (the wrapped git redirects `--global` into a read-only store path anyway):
 
   ```fish
-  sudo -u hermes git config --global --add safe.directory /mnt/hermes/mirrors/jeiang__.dotfiles.git
-  sudo -u hermes git config --global --add safe.directory /mnt/hermes/mirrors/jeiang__knowledge-base.git
-  sudo -u hermes git -C /mnt/hermes/worktrees clone /mnt/hermes/mirrors/jeiang__.dotfiles.git cornn-flaek
-  sudo -u hermes git -C /mnt/hermes/worktrees clone /mnt/hermes/mirrors/jeiang__knowledge-base.git knowledge-base
+  sudo -u hermes env HOME=/mnt/hermes git -C /mnt/hermes/worktrees clone /mnt/hermes/mirrors/jeiang__.dotfiles.git cornn-flaek
+  sudo -u hermes env HOME=/mnt/hermes git -C /mnt/hermes/worktrees clone /mnt/hermes/mirrors/jeiang__knowledge-base.git knowledge-base
   ```
 
 5. Send `/start` to the publisher bot once, then create the two cron jobs

--- a/modules/nixos/hermes-snapshot.py
+++ b/modules/nixos/hermes-snapshot.py
@@ -1,13 +1,20 @@
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import time
 
 
 def command(*args):
-    return subprocess.run(args, check=False, capture_output=True, text=True).stdout.strip()
+    # A missing binary raises FileNotFoundError before the process runs, which
+    # check=False does not catch; treat any failure to launch as empty output
+    # so an absent tool degrades a field instead of crashing the snapshot.
+    try:
+        return subprocess.run(args, check=False, capture_output=True, text=True).stdout.strip()
+    except OSError:
+        return ""
 
 
 def meminfo():
@@ -49,11 +56,11 @@ services = filter(None, os.environ.get("HERMES_SNAPSHOT_SERVICES", "").split(","
 volumes = filter(None, os.environ.get("HERMES_SNAPSHOT_VOLUMES", "").split(","))
 report = {
     "collected_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    "hostname": command("hostname"),
+    "hostname": socket.gethostname(),
     "memory": meminfo(),
     "load_average": list(os.getloadavg()),
     "boot_id": open("/proc/sys/kernel/random/boot_id", encoding="utf-8").read().strip(),
-    "generation": command("readlink", "-f", "/run/current-system"),
+    "generation": os.path.realpath("/run/current-system"),
     "services": {name: unit(name) for name in services},
     "filesystems": [filesystem(path) for path in volumes if os.path.ismount(path)],
     "backup_units": backup_units(),

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -206,6 +206,12 @@
               Environment = [
                 "CODEX_HOME=${stateDir}/codex"
                 "TZ=America/Port_of_Spain"
+                # This node has working DNS and direct reachability to
+                # api.telegram.org, so the adapter's DoH-discovered fallback-IP
+                # transport is pure downside here: it wedged startup
+                # indefinitely on an unreachable fallback chain. Force the
+                # direct httpx client instead.
+                "HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1"
               ];
               MemoryMax = "1G";
               CPUQuota = "100%";

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -96,9 +96,12 @@
         # Seed the Hermes auth store from the Codex OAuth tokens. The gateway
         # resolves the openai-codex provider from ~/.hermes/auth.json (not
         # CODEX_HOME), so without this it reports "No Codex credentials
-        # stored". Seed only when absent — Hermes manages token refresh
-        # afterward and self-heals refresh_token rotation from CODEX_HOME.
-        if [ ! -e ${stateDir}/.hermes/auth.json ]; then
+        # stored". Seed whenever the store lacks a usable openai-codex access
+        # token (missing file, empty/invalid store, or a stub left by a failed
+        # start) but never when Hermes already holds a good token — Hermes
+        # manages refresh afterward and self-heals rotation from CODEX_HOME.
+        if ! jq -e '(.providers["openai-codex"].tokens.access_token // "") | length > 0' \
+            ${stateDir}/.hermes/auth.json >/dev/null 2>&1; then
           umask 077
           jq -n --slurpfile c ${config.sops.secrets."hermes/codex-auth.json".path} \
             '{providers: {"openai-codex": {tokens: $c[0].tokens, last_refresh: (now | todateiso8601), auth_mode: "chatgpt"}}}' \

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -58,6 +58,15 @@
     # config.yaml is exactly `builtins.toJSON settings` upstream (JSON is valid
     # YAML); reproduced here so hermes-state-init can install it post-mount.
     hermesConfig = pkgs.writeText "hermes-config.yaml" (builtins.toJSON hermesSettings);
+    # The agent and Codex run plain pkgs.git, which refuses the mirrors as
+    # "dubious ownership" (they belong to hermes-publisher). Mark exactly the
+    # mirror paths safe in the hermes home gitconfig — HOME is the volume root,
+    # so this covers every git the agent spawns without a global config write.
+    mirrorPath = repo: "${stateDir}/mirrors/${builtins.replaceStrings ["/"] ["__"] repo}.git";
+    hermesGitconfig = pkgs.writeText "hermes-gitconfig" ''
+      [safe]
+      ${lib.concatMapStringsSep "\n" (repo: "\tdirectory = ${mirrorPath repo}") (builtins.attrNames config.hermes.publisherRepositories)}
+    '';
     # The persistent state lives on a nofail Hetzner Volume that mounts after
     # both systemd-tmpfiles-setup and the system activation script that the
     # upstream module uses to create ${stateDir}/.hermes, config.yaml, and
@@ -82,6 +91,7 @@
         install -d -o hermes -g hermes -m 0750 ${stateDir}/home
         install -o hermes -g hermes -m 0640 ${hermesConfig} ${stateDir}/.hermes/config.yaml
         install -o hermes -g hermes -m 0640 ${config.sops.secrets."hermes/env".path} ${stateDir}/.hermes/.env
+        install -o hermes -g hermes -m 0640 ${hermesGitconfig} ${stateDir}/.gitconfig
 
         install -d -o hermes            -g hermes           -m 0700 ${stateDir}/codex
         install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -28,6 +28,29 @@
       '';
     };
     aggregateSnapshot = pkgs.writers.writePython3Bin "hermes-snapshot-aggregate" {flakeIgnore = ["E501"];} (builtins.readFile ./hermes-snapshot-aggregate.py);
+    # The persistent state lives on a nofail Hetzner Volume that mounts long
+    # after systemd-tmpfiles-setup runs, so tmpfiles cannot reliably create
+    # these directories on the volume (they land on the pre-mount mountpoint
+    # and get shadowed). This oneshot runs after the mount, in the host
+    # namespace, so the sandboxed services below can build their mount
+    # namespaces against directories that actually exist.
+    stateInit = pkgs.writeShellApplication {
+      name = "hermes-state-init";
+      runtimeInputs = [pkgs.coreutils];
+      text = ''
+        install -d -o hermes            -g hermes         -m 0700 ${stateDir}/codex
+        install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher
+        install -d -o hermes-publisher  -g hermes-publisher -m 0700 ${stateDir}/publisher/home
+        install -d -o hermes-publisher  -g hermes-publisher -m 0700 ${stateDir}/publisher/gh
+        install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher/completed
+        install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher/rejected
+        install -d -o hermes-publisher  -g hermes-publish  -m 0750 ${stateDir}/mirrors
+        install -d -o hermes            -g hermes-publish  -m 0750 ${workspace}
+        install -d -o hermes            -g hermes-publish  -m 2770 ${workspace}/.publisher-requests
+        install -d -o root              -g hermes          -m 0750 ${stateDir}/reports
+        install -d -o root              -g hermes          -m 0750 ${stateDir}/reports/history
+      '';
+    };
   in {
     imports = [inputs.hermes-agent.nixosModules.default];
 
@@ -124,7 +147,24 @@
 
       systemd = {
         services = {
+          hermes-state-init = {
+            description = "Create Hermes state directories on the mounted volume";
+            wantedBy = ["multi-user.target"];
+            before = ["hermes-agent.service" "hermes-publisher.service" "hermes-snapshot-aggregate.service"];
+            unitConfig = {
+              ConditionPathIsMountPoint = stateDir;
+              RequiresMountsFor = stateDir;
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${stateInit}/bin/hermes-state-init";
+            };
+          };
+
           hermes-agent = {
+            requires = ["hermes-state-init.service"];
+            after = ["hermes-state-init.service"];
             unitConfig = {
               ConditionPathIsMountPoint = stateDir;
               RequiresMountsFor = stateDir;
@@ -147,7 +187,8 @@
           hermes-publisher = {
             description = "Hermes GitHub publication approval broker";
             wantedBy = ["multi-user.target"];
-            after = ["network-online.target"];
+            requires = ["hermes-state-init.service"];
+            after = ["network-online.target" "hermes-state-init.service"];
             wants = ["network-online.target"];
             unitConfig = {
               ConditionPathIsMountPoint = stateDir;
@@ -181,7 +222,8 @@
 
           hermes-snapshot-aggregate = {
             description = "Aggregate fleet observed snapshots for Hermes";
-            after = ["network-online.target" "observed-snapshot.service"];
+            requires = ["hermes-state-init.service"];
+            after = ["network-online.target" "observed-snapshot.service" "hermes-state-init.service"];
             wants = ["network-online.target"];
             unitConfig = {
               ConditionPathIsMountPoint = stateDir;
@@ -207,23 +249,17 @@
           };
         };
 
-        # The Hermes agent owns its worktrees outright (single-writer .git);
-        # the publisher only ever reads them, via the hermes-publish group.
-        # The publisher's own tree, including the bare mirrors Hermes clones
-        # from, is publisher-owned so the agent cannot swap out directories
-        # that feed the credentialed git/gh processes.
+        # Directory creation is handled by hermes-state-init (post-mount, in
+        # the host namespace) because these paths live on a nofail Volume that
+        # mounts after systemd-tmpfiles-setup. The agent owns its worktrees
+        # outright (single-writer .git); the publisher only reads them, via the
+        # hermes-publish group; the publisher's own tree and the bare mirrors
+        # are publisher-owned so the agent cannot swap out directories feeding
+        # the credentialed git/gh processes. tmpfiles only ages out the
+        # snapshot history here (the `e` type never creates, so it is immune to
+        # the mount-ordering race above).
         tmpfiles.rules = [
-          "d ${stateDir}/codex 0700 hermes hermes - -"
-          "d ${stateDir}/publisher 0750 hermes-publisher hermes-publisher - -"
-          "d ${stateDir}/publisher/home 0700 hermes-publisher hermes-publisher - -"
-          "d ${stateDir}/publisher/gh 0700 hermes-publisher hermes-publisher - -"
-          "d ${stateDir}/publisher/completed 0750 hermes-publisher hermes-publisher - -"
-          "d ${stateDir}/publisher/rejected 0750 hermes-publisher hermes-publisher - -"
-          "d ${stateDir}/mirrors 0750 hermes-publisher hermes-publish - -"
-          "d ${workspace} 0750 hermes hermes-publish - -"
-          "d ${workspace}/.publisher-requests 2770 hermes hermes-publish - -"
-          "d ${stateDir}/reports 0750 root hermes - -"
-          "d ${stateDir}/reports/history 0750 root hermes 7d -"
+          "e ${stateDir}/reports/history - - - 7d"
         ];
       };
 

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -79,7 +79,7 @@
     # build their namespaces against.
     stateInit = pkgs.writeShellApplication {
       name = "hermes-state-init";
-      runtimeInputs = [pkgs.coreutils];
+      runtimeInputs = [pkgs.coreutils pkgs.jq];
       text = ''
         # Agent home == volume root; 0751 keeps it traversable by the
         # publisher (hermes-publish group / other) without granting write.
@@ -92,6 +92,20 @@
         install -o hermes -g hermes -m 0640 ${hermesConfig} ${stateDir}/.hermes/config.yaml
         install -o hermes -g hermes -m 0640 ${config.sops.secrets."hermes/env".path} ${stateDir}/.hermes/.env
         install -o hermes -g hermes -m 0640 ${hermesGitconfig} ${stateDir}/.gitconfig
+
+        # Seed the Hermes auth store from the Codex OAuth tokens. The gateway
+        # resolves the openai-codex provider from ~/.hermes/auth.json (not
+        # CODEX_HOME), so without this it reports "No Codex credentials
+        # stored". Seed only when absent — Hermes manages token refresh
+        # afterward and self-heals refresh_token rotation from CODEX_HOME.
+        if [ ! -e ${stateDir}/.hermes/auth.json ]; then
+          umask 077
+          jq -n --slurpfile c ${config.sops.secrets."hermes/codex-auth.json".path} \
+            '{providers: {"openai-codex": {tokens: $c[0].tokens, last_refresh: (now | todateiso8601), auth_mode: "chatgpt"}}}' \
+            > ${stateDir}/.hermes/auth.json
+          chown hermes:hermes ${stateDir}/.hermes/auth.json
+          chmod 0600 ${stateDir}/.hermes/auth.json
+        fi
 
         install -d -o hermes            -g hermes           -m 0700 ${stateDir}/codex
         install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher

--- a/modules/nixos/hermes.nix
+++ b/modules/nixos/hermes.nix
@@ -28,27 +28,72 @@
       '';
     };
     aggregateSnapshot = pkgs.writers.writePython3Bin "hermes-snapshot-aggregate" {flakeIgnore = ["E501"];} (builtins.readFile ./hermes-snapshot-aggregate.py);
-    # The persistent state lives on a nofail Hetzner Volume that mounts long
-    # after systemd-tmpfiles-setup runs, so tmpfiles cannot reliably create
-    # these directories on the volume (they land on the pre-mount mountpoint
-    # and get shadowed). This oneshot runs after the mount, in the host
-    # namespace, so the sandboxed services below can build their mount
-    # namespaces against directories that actually exist.
+    hermesSettings = {
+      model = {
+        provider = "openai-codex";
+        default = "gpt-5.6-terra";
+        openai_runtime = "codex_app_server";
+      };
+      fallback_providers = [];
+      timezone = "America/Port_of_Spain";
+      agent.reasoning_effort = "medium";
+      memory = {
+        memory_enabled = true;
+        user_profile_enabled = true;
+        write_approval = false;
+      };
+      skills.write_approval = true;
+      unauthorized_dm_behavior = "ignore";
+      gateway.platforms.telegram.extra = {
+        # The SOPS environment file supplies TELEGRAM_ALLOWED_USERS. Hermes
+        # treats an empty allowlist as unrestricted. Telegram group IDs are
+        # numeric, so this impossible nonempty entry denies every group while
+        # direct-message authorization stays environment-based.
+        allowed_chats = ["__hermes_dm_only__"];
+        group_allowed_chats = [];
+        guest_mode = false;
+        observe_unmentioned_group_messages = false;
+      };
+    };
+    # config.yaml is exactly `builtins.toJSON settings` upstream (JSON is valid
+    # YAML); reproduced here so hermes-state-init can install it post-mount.
+    hermesConfig = pkgs.writeText "hermes-config.yaml" (builtins.toJSON hermesSettings);
+    # The persistent state lives on a nofail Hetzner Volume that mounts after
+    # both systemd-tmpfiles-setup and the system activation script that the
+    # upstream module uses to create ${stateDir}/.hermes, config.yaml, and
+    # .env. Those all run pre-mount, so their output lands on the shadowed
+    # pre-mount mountpoint and the volume root stays root:root and empty. This
+    # oneshot runs after the mount, in the host namespace, and is the single
+    # authority for the on-volume layout: it owns the volume root as the hermes
+    # home, recreates the agent's ~/.hermes tree with config.yaml and .env, and
+    # creates the publisher/mirror/report directories the sandboxed services
+    # build their namespaces against.
     stateInit = pkgs.writeShellApplication {
       name = "hermes-state-init";
       runtimeInputs = [pkgs.coreutils];
       text = ''
-        install -d -o hermes            -g hermes         -m 0700 ${stateDir}/codex
+        # Agent home == volume root; 0751 keeps it traversable by the
+        # publisher (hermes-publish group / other) without granting write.
+        install -d -o hermes -g hermes -m 0751 ${stateDir}
+        install -d -o hermes -g hermes -m 2770 ${stateDir}/.hermes
+        for sub in cron sessions logs memories plugins; do
+          install -d -o hermes -g hermes -m 2770 "${stateDir}/.hermes/$sub"
+        done
+        install -d -o hermes -g hermes -m 0750 ${stateDir}/home
+        install -o hermes -g hermes -m 0640 ${hermesConfig} ${stateDir}/.hermes/config.yaml
+        install -o hermes -g hermes -m 0640 ${config.sops.secrets."hermes/env".path} ${stateDir}/.hermes/.env
+
+        install -d -o hermes            -g hermes           -m 0700 ${stateDir}/codex
         install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher
         install -d -o hermes-publisher  -g hermes-publisher -m 0700 ${stateDir}/publisher/home
         install -d -o hermes-publisher  -g hermes-publisher -m 0700 ${stateDir}/publisher/gh
         install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher/completed
         install -d -o hermes-publisher  -g hermes-publisher -m 0750 ${stateDir}/publisher/rejected
-        install -d -o hermes-publisher  -g hermes-publish  -m 0750 ${stateDir}/mirrors
-        install -d -o hermes            -g hermes-publish  -m 0750 ${workspace}
-        install -d -o hermes            -g hermes-publish  -m 2770 ${workspace}/.publisher-requests
-        install -d -o root              -g hermes          -m 0750 ${stateDir}/reports
-        install -d -o root              -g hermes          -m 0750 ${stateDir}/reports/history
+        install -d -o hermes-publisher  -g hermes-publish   -m 0750 ${stateDir}/mirrors
+        install -d -o hermes            -g hermes-publish   -m 0750 ${workspace}
+        install -d -o hermes            -g hermes-publish   -m 2770 ${workspace}/.publisher-requests
+        install -d -o root              -g hermes           -m 0750 ${stateDir}/reports
+        install -d -o root              -g hermes           -m 0750 ${stateDir}/reports/history
       '';
     };
   in {
@@ -116,33 +161,11 @@
         environmentFiles = [config.sops.secrets."hermes/env".path];
         extraDependencyGroups = ["messaging"];
         extraPackages = [pkgs.codex];
-        settings = {
-          model = {
-            provider = "openai-codex";
-            default = "gpt-5.6-terra";
-            openai_runtime = "codex_app_server";
-          };
-          fallback_providers = [];
-          timezone = "America/Port_of_Spain";
-          agent.reasoning_effort = "medium";
-          memory = {
-            memory_enabled = true;
-            user_profile_enabled = true;
-            write_approval = false;
-          };
-          skills.write_approval = true;
-          unauthorized_dm_behavior = "ignore";
-          gateway.platforms.telegram.extra = {
-            # The SOPS environment file supplies TELEGRAM_ALLOWED_USERS.
-            # Hermes treats an empty allowlist as unrestricted. Telegram group
-            # IDs are numeric, so this impossible nonempty entry denies every
-            # group while direct-message authorization stays environment-based.
-            allowed_chats = ["__hermes_dm_only__"];
-            group_allowed_chats = [];
-            guest_mode = false;
-            observe_unmentioned_group_messages = false;
-          };
-        };
+        # The upstream activation script also renders this to config.yaml, but
+        # pre-mount (shadowed); hermes-state-init reinstalls the same content
+        # onto the volume. Kept here so the module's own settings-aware logic
+        # (e.g. mcp_servers merge) still sees the configuration.
+        settings = hermesSettings;
       };
 
       systemd = {

--- a/modules/nixos/observed-snapshot.nix
+++ b/modules/nixos/observed-snapshot.nix
@@ -33,6 +33,10 @@
         services = {
           observed-snapshot = {
             description = "Write a bounded observed host snapshot";
+            # systemctl is the one external tool the snapshot still shells out
+            # to (service/backup unit states); everything else is read from
+            # /proc or the Python stdlib.
+            path = [pkgs.systemd];
             serviceConfig = {
               Type = "oneshot";
               User = "root";


### PR DESCRIPTION
## Summary

First `just deploy legion-node3` after enabling Hermes hit two activation-time failures. Both fixed here.

### observed-snapshot: `FileNotFoundError: 'hostname'`
A systemd unit's PATH doesn't include `hostname`/`readlink`/`systemctl`, and `subprocess.run` raises on a missing binary regardless of `check=False`, so the first shell-out crashed the oneshot.

- `hostname` → `socket.gethostname()`, `readlink -f` → `os.path.realpath` (stdlib, no subprocess).
- `command()` now swallows `OSError` so an absent tool degrades a field instead of crashing.
- `systemd` added to the unit PATH for the one remaining shell-out (`systemctl`).

### hermes-publisher: `status=226/NAMESPACE`
`ProtectSystem=strict` + `ReadWritePaths` require every listed path to exist before the namespace is built, but the `tmpfiles` rules that create them run at early boot, before the nofail `/mnt/hermes` Volume mounts — so the directories were only ever created on the shadowed pre-mount mountpoint.

- New `hermes-state-init` oneshot creates the state directories post-mount, in the host namespace; `hermes-agent`, `hermes-publisher`, and `hermes-snapshot-aggregate` now `require`/`after` it.
- `tmpfiles` is left only to age out snapshot history, via the non-creating `e` type (immune to the mount-ordering race).

## Validation

- `nix eval --impure --raw .#nixosConfigurations.legion-node3.config.system.build.toplevel.drvPath`
- Built the `observed-snapshot` writer derivation (flake8 gate passes).
- `just fmt`, statix, editorconfig, treefmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)