### PR TITLE
chore(flake): pick up the calendar, traversal and skills fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785108558,
-        "narHash": "sha256-A6vnRgbQ8W3HOEQJATJhagEnV/fAMH34+Nu1vhGMwzA=",
+        "lastModified": 1785110180,
+        "narHash": "sha256-A6sNW34D572mqu/YlnXr9CoClFalLlve0DrZ50d4RF0=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "19997ffda2ea1bfd78d343a5739e913c3315c307",
+        "rev": "a31776642271876068868b0e559da8e4ee888810",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785110180,
-        "narHash": "sha256-A6sNW34D572mqu/YlnXr9CoClFalLlve0DrZ50d4RF0=",
+        "lastModified": 1785111447,
+        "narHash": "sha256-G9ek0/M32hQi3jyaPoPLj+lRAIAMe1OpgomSzb7ykoI=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "a31776642271876068868b0e559da8e4ee888810",
+        "rev": "bf08654394ef8768b2ac3408614b9aca0177cac8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785099797,
-        "narHash": "sha256-QvhaJ8eu1skJTIuBA70gKqNe9rWuCo58qEutCIqZEoA=",
+        "lastModified": 1785108558,
+        "narHash": "sha256-A6vnRgbQ8W3HOEQJATJhagEnV/fAMH34+Nu1vhGMwzA=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "52fae7ef7ae000de3de358bb7b0632eb9b0a0fc9",
+        "rev": "19997ffda2ea1bfd78d343a5739e913c3315c307",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `hermes-agent-config` to `a317766` for three fixes found on the first
live sync (jeiang/hermes-agent-config#11, #12).

## 1. State directory traversal — the one that broke both integrations

`/mnt/hermes` is mode **2770 `hermes:hermes`**. No "other" permission means
no traversal, and the broker, command runner, and calendar holder are each
deliberately outside group `hermes` — so none could reach subdirectories
**they themselves own**. Every path looked correctly owned and still
returned EACCES.

The upstream module forces 2770 via both a tmpfiles rule and an activation
`chmod`, overriding `hermes-state-init`'s 0751.

Now re-asserted as a privileged `ExecStartPre` on all three units, which is
ordering-independent. Confirmed on the node: at 2770 the calendar user could
not write its own directory; at 0751 it could.

This is very likely why Actual failed too — its data directory is under
`/mnt/hermes/publisher/`.

## 2. First sync exited 1

`vdirsyncer discover` prompts to create missing local collections, read EOF
under systemd, and failed. Now answered via redirect (not a pipe — the
wrapper runs under `pipefail` and `yes` would take SIGPIPE), scoped to
`discover` so it can never auto-approve a destructive prompt.

## 3. Literal `%s` in the storage path

vdirsyncer 0.20 performs no `%s` substitution, so it tried to create a
directory named `%s`. Path is now the parent directory, which is what
filesystem discovery expects.

Also filtered the remote to `VEVENT`, keeping iCloud's Reminders list out of
a directory khal reads as events.

## Verified on the node3 config

```
brokerPre:  ['+.../chmod 0751 /mnt/hermes']
calPre:     ['+.../chmod 0751 /mnt/hermes']
runnerPre:  ['+.../chmod 0751 /mnt/hermes']
```

## After deploy

```sh
systemctl restart hermes-calendar-sync.service
ls /mnt/hermes/calendar
```

Expect three directories — Family, Work, Home — and no Reminders. Then ask
the agent to list budget accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)