### PR TITLE
chore(flake): bridge Hermes skills into the Codex app-server runtime

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785111447,
-        "narHash": "sha256-G9ek0/M32hQi3jyaPoPLj+lRAIAMe1OpgomSzb7ykoI=",
+        "lastModified": 1785118342,
+        "narHash": "sha256-vTh4MZSYAmJdmTgT5jVcrKhwQbhGhTqYuqmA4eGd0h4=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "bf08654394ef8768b2ac3408614b9aca0177cac8",
+        "rev": "aeba36e608a82c4fc87b8b630ed691932a4133c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `hermes-agent-config` to `aeba36e` (jeiang/hermes-agent-config#14).

## Why

This deployment runs `openai_runtime = "codex_app_server"`, so **Codex owns
the loop** and never enters Hermes' native skill path. The generated skills
reached the model neither natively nor through tools — the agent answered
budget questions from general knowledge because it had never been told the
capability existed.

Two independent mechanisms are fixed upstream:

1. **`[mcp_servers.hermes-tools]` is now declared** in the generated Codex
   config, exposing `skills_list` and `skill_view`. The pinned Hermes ships
   that MCP server but contains **no code to register it**, so there was no
   migration to reuse. The command uses the *effective* package's own
   interpreter — only that one can import the module.
2. **A normalised native skill tree** is installed under Codex's `hermes`
   namespace, with every `SKILL.md` materialised as a real file. Previously
   the leaves were symlinks from `symlinkJoin`, which Codex did not pick up.

Only the `hermes` namespace is replaced; Codex's `.system` set and anything
installed outside Nix survive.

## Verified against the node3 configuration

- The agent unit installs the normalised tree before starting (4th
  `ExecStartPre`), with `User=hermes` and `WorkingDirectory=/mnt/hermes/worktrees`.
- Its generated Codex config carries the MCP registration.

The config itself is an `x86_64-linux` derivation and cannot be realised on
the author's darwin machine — the pre-existing builder limitation. It is
covered by the new `codex-config-mcp` check, which asserts the config parses
under `tomllib`, declares `mcp_servers.hermes-tools`, and still carries
`default_permissions` and the custom `permissions.hermes` profile. CI builds
that check on Linux.

## After deploying — a new Telegram session is required

Codex assembles its skill catalog at session start, so an existing
conversation will not see either mechanism. Send `/reset`, then:

```
Call skills_list and return every available Hermes skill.
```

That exercises the **MCP** path. Asking what skills it has exercises Codex's
**native** catalog. They are separate now, so check both rather than
concluding from one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)