### PR TITLE
chore(flake): run Hermes on gpt-5.6-luna at high reasoning effort

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785123079,
-        "narHash": "sha256-ghRvmjxjyJsC/+gXductqIg7KEs99Wq9A1ZXKdFZ8F0=",
+        "lastModified": 1785137794,
+        "narHash": "sha256-8uFsy0D4OCYqTwT1DGNBkLR5rCxhAYtubZDnMfzXSO8=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "d28ca617aaf453710c5c7d4cfcc3f657c7705c6f",
+        "rev": "3a83990201b4da8729b1f87a0e0eac305b412451",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `hermes-agent-config` to `3a83990` (jeiang/hermes-agent-config#16),
switching from `gpt-5.6-terra` / `medium` to `gpt-5.6-luna` / `high`.

Nothing is configured in this repo. The module's defaults carry the
deployment's values (ADR 0010) and this repo restates none of them, so the
lock bump is the entire change.

## Verified against the node3 configuration

```json
{"model": "gpt-5.6-luna", "effort": "high",
 "settingsModel": "gpt-5.6-luna", "settingsEffort": "high"}
```

Both consumers moved together. The model name and reasoning effort each
appear in **two** places — the Codex runtime profile and the Hermes agent
settings — and are driven from one option apiece, so a half-applied change
isn't possible.

## After deploying

Codex resolves model names at runtime, so an invalid id fails on the first
Telegram turn rather than at build or deploy time. Send a message and
confirm you get a reply before assuming the switch took.

🤖 Generated with [Claude Code](https://claude.com/claude-code)