### PR TITLE
chore(flake): make synced calendar items readable by the agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785137794,
-        "narHash": "sha256-8uFsy0D4OCYqTwT1DGNBkLR5rCxhAYtubZDnMfzXSO8=",
+        "lastModified": 1785142601,
+        "narHash": "sha256-063LEB0gdedasP0P7zc/DWwZgSAgTkTx/SNnD+JlQLY=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "3a83990201b4da8729b1f87a0e0eac305b412451",
+        "rev": "19b001d16e7fc8d898eac7f8db5d4d39afd26c0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `hermes-agent-config` to `19b001d`
(jeiang/hermes-agent-config#17).

The agent could not read the Local Calendar. Its group membership and the
directory modes were both correct — every `.ics` file was `0600`.

vdirsyncer writes items through `tempfile.mkstemp`, which **hard-codes 0600
and ignores umask**, so the sync unit's `UMask = "0007"` never applied.
Confirmed directly:

```
umask 0007 -> mkstemp mode:     0o600
umask 0007 -> open(0666) mode:  0o660
```

Group access is now normalised after each sync, additively so the
collections' setgid bit survives.

## After deploying

A manual `chown`/`chmod` holds only until the next sync writes new files, so
this needs the deploy to stick. Then:

```sh
ls -l /mnt/hermes/calendar/*/ | head
```

Expect `-rw-rw----`. The agent should be able to read the schedule without
further intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)