### PR TITLE
chore(flake): give the agent the hermes CLI so it can schedule

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785142601,
-        "narHash": "sha256-063LEB0gdedasP0P7zc/DWwZgSAgTkTx/SNnD+JlQLY=",
+        "lastModified": 1785198341,
+        "narHash": "sha256-5DxmzJwzRFUW5eB6i8+4McjyXenSOAL1BILensjdGPQ=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "19b001d16e7fc8d898eac7f8db5d4d39afd26c0e",
+        "rev": "9c028bb8441c8513ed9cab70d81bbad6eefabefa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `hermes-agent-config` to `9c028bb`
(jeiang/hermes-agent-config#18). Two failures, one cause.

## The agent could not run `hermes`

Codex hands shell commands a **login-style PATH** that excludes the systemd
unit's PATH. Observed on the node:

```
/run/wrappers/bin:/mnt/hermes/.nix-profile/bin:/nix/profile/bin:
/mnt/hermes/.local/state/nix/profile/bin:/etc/profiles/per-user/hermes/bin:
/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin

hermes-request -> /etc/profiles/per-user/hermes/bin/hermes-request
```

So only binaries in the per-user profile are usable by the agent. The agent
package was never in that list — it lived only on the unit's PATH, which its
shell never sees. Hence `hermes-request` working while `hermes cron list`
was command-not-found.

This is not cosmetic: the `hermes-tools` MCP surface exposes a fixed tool
tuple with **no cron tools and no override**, so under this runtime the CLI
is the agent's only route to scheduling anything.

## The briefing skipped itself — working as intended

An unpinned cron job records the model resolved at creation and fails closed
if the global default later differs, rather than spending on a model it was
not created against. Switching to `gpt-5.6-luna` tripped it.

**This recurs on every model change.** After deploying, re-pin:

```sh
hermes cron list
hermes cron edit <job-id> --model gpt-5.6-luna
```

Documented in the runbook.

## Verified against the node3 configuration

```json
{"profileHasHermesCli": true, "pkgCount": 18}
```

## After deploying

Send `/reset`, then ask it to schedule something — it should use
`hermes cron create` rather than reporting no tool. Then re-pin the briefing
job so it resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)