### PR TITLE
chore(hermes): pin broker reliability hotfix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785337271,
-        "narHash": "sha256-hgd8yrG5KsApZQk4WnjWVWB/lZ6wzea85nxsqfX38Ok=",
+        "lastModified": 1785341904,
+        "narHash": "sha256-QuwpBY4H/FCbsLsqf5blYkV7DENeTkpeCLjdhaVju9g=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "7fa7df8c9efcc28b081b09901b490472486677f1",
+        "rev": "d70b9b68b7d1889e068ae3ee604c921b1857b7a4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785206991,
-        "narHash": "sha256-PCuYCJnjpwrCLLy3eqF+z0M5kIiiHvvWLphKEreM5O8=",
+        "lastModified": 1785337271,
+        "narHash": "sha256-hgd8yrG5KsApZQk4WnjWVWB/lZ6wzea85nxsqfX38Ok=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "970c253c98353e7c779a48d4707989d3da7c118c",
+        "rev": "7fa7df8c9efcc28b081b09901b490472486677f1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785198341,
-        "narHash": "sha256-5DxmzJwzRFUW5eB6i8+4McjyXenSOAL1BILensjdGPQ=",
+        "lastModified": 1785206991,
+        "narHash": "sha256-PCuYCJnjpwrCLLy3eqF+z0M5kIiiHvvWLphKEreM5O8=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "9c028bb8441c8513ed9cab70d81bbad6eefabefa",
+        "rev": "970c253c98353e7c779a48d4707989d3da7c118c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What changed

Pins `hermes-agent-config` to `970c253c98353e7c779a48d4707989d3da7c118c`, the P1 broker correctness hotfix from jeiang/hermes-agent-config#19.

## Deployment boundary

This PR prepares deployment point D1 for `legion-node3`. It does not deploy or merge anything. Activation still requires explicit approval after privileged P0 mount-namespace checks and confirmation that no unresolved queue state is present.

## Validation

- `nix fmt`
- `nix eval .#nixosConfigurations.legion-node3.config.system.build.toplevel.drvPath --raw`
- `nix flake check --impure --keep-going` evaluated all NixOS configurations and ran local checks; final completion remains limited by expected aarch64-darwin versus x86_64-linux build incompatibility
- pre-commit editorconfig and treefmt checks
