### PR TITLE
chore(hermes): pin Telegram streaming support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785338079,
-        "narHash": "sha256-CYbPYWpsi1kDQMxMx/n3a9F+UI/46C7xnZ+WXvY6vmY=",
+        "lastModified": 1785341981,
+        "narHash": "sha256-vX6KIqkosEGnMOlF8DV7OjbD/9akC2fQOEQb7hztET0=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "a9ba2fe4bbe5dd5f535de22e5fa9b039c795af8d",
+        "rev": "b9a325ec41cea8025e28f9d30f8a7342325c3016",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785208679,
-        "narHash": "sha256-+o6ZSoOAOxiQ08N6ZxC2kO7K2y/E3jEq8OFijYARxCg=",
+        "lastModified": 1785338079,
+        "narHash": "sha256-CYbPYWpsi1kDQMxMx/n3a9F+UI/46C7xnZ+WXvY6vmY=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "8ab542325af5584ef20173395497690b31432403",
+        "rev": "a9ba2fe4bbe5dd5f535de22e5fa9b039c795af8d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785206991,
-        "narHash": "sha256-PCuYCJnjpwrCLLy3eqF+z0M5kIiiHvvWLphKEreM5O8=",
+        "lastModified": 1785208679,
+        "narHash": "sha256-+o6ZSoOAOxiQ08N6ZxC2kO7K2y/E3jEq8OFijYARxCg=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "970c253c98353e7c779a48d4707989d3da7c118c",
+        "rev": "8ab542325af5584ef20173395497690b31432403",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- pin hermes-agent-config to the P2 Codex-to-Telegram streaming implementation
- keep this deployment change stacked on the undeployed D1 reliability pin

## Validation

- `nix eval .#nixosConfigurations.legion-node3.config.system.build.toplevel.drvPath --raw`
  - `/nix/store/hbx91b9z9qb4nsqssava9p24biwlcnkq-nixos-system-legion-node3-26.11.20260718.61b7c44.drv`
- editorconfig and treefmt pre-commit checks pass

## Deployment gate

No deployment has been performed. D2 requires explicit authorization after #61 and the P2 implementation PR are reviewed.