### PR TITLE
chore(hermes): pin approval RPC support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785343220,
-        "narHash": "sha256-x/9LrptP2L1HTHefiMxxNLH6HXMs/ACkKn+jgZ5VSuM=",
+        "lastModified": 1785346058,
+        "narHash": "sha256-4MkL0y+wFOGzksSTceeOqHW4RW1FJjeMocbihmHJPZk=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "7c5bef40dd25a29c7c0127f7ca22be32de11116b",
+        "rev": "4dd8d35b6e77ed86b323fc314ed8af05555aa411",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785210515,
-        "narHash": "sha256-rDBcXrilwuJnIGpoKvTrwYn0D4Ru6sQDpijCMp5wXtk=",
+        "lastModified": 1785343220,
+        "narHash": "sha256-x/9LrptP2L1HTHefiMxxNLH6HXMs/ACkKn+jgZ5VSuM=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "05336a8943eeecc0c9f4267f1f16ac7c3a2be4bb",
+        "rev": "7c5bef40dd25a29c7c0127f7ca22be32de11116b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785208679,
-        "narHash": "sha256-+o6ZSoOAOxiQ08N6ZxC2kO7K2y/E3jEq8OFijYARxCg=",
+        "lastModified": 1785210515,
+        "narHash": "sha256-rDBcXrilwuJnIGpoKvTrwYn0D4Ru6sQDpijCMp5wXtk=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "8ab542325af5584ef20173395497690b31432403",
+        "rev": "05336a8943eeecc0c9f4267f1f16ac7c3a2be4bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- pin hermes-agent-config P3 Unix RPC implementation
- expose the broker socket and sandbox policy through the pinned module

## Validation
- legion-node3 system derivation evaluates to `/nix/store/n5f94nabhd9g5mbf18xlm5p68m0cqj2m-nixos-system-legion-node3-26.11.20260718.61b7c44.drv`
- pre-commit editorconfig and treefmt checks pass

## Deployment gate D3
Do not merge/deploy until PR jeiang/hermes-agent-config#21 is reviewed. Activation requires explicit authorization, then Linux SO_PEERCRED tests, socket ACL and namespace checks for agent/broker/dispatcher/runner, duplicate-nonce crash tests, and p95 durable-ack and Telegram-initiation measurements. File fallback remains available for rollback.

Stacked on #62.