### PR TITLE
chore(hermes): pin broker MCP discovery

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785211542,
-        "narHash": "sha256-GOsMCdytca2YU6nuAgeHIET5DdmIymbTJzTxhkztD20=",
+        "lastModified": 1785346513,
+        "narHash": "sha256-/MYuvEKwLnfDz8KLST8fzy4tAgQeF19xebl6mDXNfZk=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "a7d88271a305e2e3119a71f1c7b14b8129cb5d0c",
+        "rev": "bca40a03a426b6eb13bf235f86ec8135c0979e4d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785210515,
-        "narHash": "sha256-rDBcXrilwuJnIGpoKvTrwYn0D4Ru6sQDpijCMp5wXtk=",
+        "lastModified": 1785211542,
+        "narHash": "sha256-GOsMCdytca2YU6nuAgeHIET5DdmIymbTJzTxhkztD20=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "05336a8943eeecc0c9f4267f1f16ac7c3a2be4bb",
+        "rev": "a7d88271a305e2e3119a71f1c7b14b8129cb5d0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- pin hermes-agent-config P4 typed Broker MCP facade
- register the credential-cleared `hermes-broker` stdio server in Codex configuration

## Validation
- legion-node3 evaluates to `/nix/store/218z59ji5q0fzygawmlbqm6bqy9chjwr-nixos-system-legion-node3-26.11.20260718.61b7c44.drv`
- pre-commit editorconfig and treefmt checks pass

## Deployment gate D4
Do not merge/deploy until jeiang/hermes-agent-config#22 is reviewed. Activation requires explicit authorization, then a fresh Codex/Telegram session confirming healthy MCP startup, exact tool schemas and annotations, matching policy version, no inherited credential environment, successful bounded status/cancel calls, and working `hermes-request` fallback.

Stacked on #63.