### PR TITLE
chore(hermes): pin execution RPC

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785211542,
-        "narHash": "sha256-GOsMCdytca2YU6nuAgeHIET5DdmIymbTJzTxhkztD20=",
+        "lastModified": 1785213508,
+        "narHash": "sha256-F21OwhZ22aATxr0plxtT9TIjlNIUqLuSeny9AdWr69w=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "a7d88271a305e2e3119a71f1c7b14b8129cb5d0c",
+        "rev": "c4b20201db5556211f3cf3e79f197b6266b74652",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785213508,
-        "narHash": "sha256-F21OwhZ22aATxr0plxtT9TIjlNIUqLuSeny9AdWr69w=",
+        "lastModified": 1785346807,
+        "narHash": "sha256-3kaDengA8dSXe/TZ5/6BdJykOqyZpTZX6hjbZCmYMqU=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "c4b20201db5556211f3cf3e79f197b6266b74652",
+        "rev": "52f9be11acbc0c9bbfc4aac87f84f16e08416879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- pin hermes-agent-config to P5 commit c4b20201db5556211f3cf3e79f197b6266b74652
- stage socket-activated command and fixed-service execution RPC for legion-node3
- do not deploy or activate the new units

## Validation

- lock update changes only hermes-agent-config
- pre-commit editorconfig and treefmt pass
- legion-node3 evaluates to /nix/store/s4b03bylw3bkxpsqpqx4m9xr9xy89n22-nixos-system-legion-node3-26.11.20260718.61b7c44.drv

## Explicit D5 deployment gates

- confirm legacy dispatch, inflight, and processed queues are empty
- verify command.sock and service.sock inherited FDs and peer identities
- run Bubblewrap hidden-path, cancellation, timeout, and descendant-termination tests on Linux
- run crash tests across accept, claim, execution, and result reconciliation
- confirm Hermes and broker MCP cannot connect to either execution socket

Activation requires separate explicit authorization.