### PR TITLE
chore(hermes): pin structured execution

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785347396,
-        "narHash": "sha256-742Q6T+IxdIWKMJAglxn8Bv9TnIKNgduIgwrfy1hXRQ=",
+        "lastModified": 1785348302,
+        "narHash": "sha256-hux9Hz595pI2WXlH0bihMXjZuKYjo3B+ftoYlJC6x/Y=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "b38aa4bfdec6eb3b6a6b6d7f285cceea0c6f0da8",
+        "rev": "85bdd4a60f4a8ed67bacc8c29a9e13b63741ea49",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785213508,
-        "narHash": "sha256-F21OwhZ22aATxr0plxtT9TIjlNIUqLuSeny9AdWr69w=",
+        "lastModified": 1785215552,
+        "narHash": "sha256-2FVgdMsFQqkmxN7nBRzGdpEioU8K2l296tR5PPFsIYU=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "c4b20201db5556211f3cf3e79f197b6266b74652",
+        "rev": "5c3538a897d6e36e76722bb103fa290012324b55",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785215552,
-        "narHash": "sha256-2FVgdMsFQqkmxN7nBRzGdpEioU8K2l296tR5PPFsIYU=",
+        "lastModified": 1785347396,
+        "narHash": "sha256-742Q6T+IxdIWKMJAglxn8Bv9TnIKNgduIgwrfy1hXRQ=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "5c3538a897d6e36e76722bb103fa290012324b55",
+        "rev": "b38aa4bfdec6eb3b6a6b6d7f285cceea0c6f0da8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785348302,
-        "narHash": "sha256-hux9Hz595pI2WXlH0bihMXjZuKYjo3B+ftoYlJC6x/Y=",
+        "lastModified": 1785349510,
+        "narHash": "sha256-oMcV0ZGgRb0N5EQwiTi949Ux8Cj3aWvIq5wkR/XGhDM=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "85bdd4a60f4a8ed67bacc8c29a9e13b63741ea49",
+        "rev": "ae31df08c522779152abb7aaf315da2c4f7c6f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- pin hermes-agent-config to P6 commit 5c3538a897d6e36e76722bb103fa290012324b55
- stage structured argv, exact command batches, mutating broker MCP tools, and untrusted Nix client access for legion-node3
- do not deploy or activate the change

## Validation

- lock update changes only hermes-agent-config
- pre-commit editorconfig and treefmt pass
- legion-node3 evaluates to /nix/store/5yizivyi6pnwyra9bjqylqjw34vhg7my-nixos-system-legion-node3-26.11.20260718.61b7c44.drv

## Explicit D6 deployment gates

- confirm no pending legacy shell approvals or command manifests
- verify hermes-command is allowed but not trusted by nix-daemon
- run Linux Bubblewrap cwd-fd, hidden-path, cancellation, timeout, and descendant tests
- validate argv fidelity, fail-stop and parallel batches, callback hashes, policy drift, and fresh-session MCP tool selection
- monitor nix-daemon resource and store growth because daemon work is outside the runner cgroup

Activation requires separate explicit authorization.