### PR TITLE
chore(hermes): pin audited capability grants

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785215552,
-        "narHash": "sha256-2FVgdMsFQqkmxN7nBRzGdpEioU8K2l296tR5PPFsIYU=",
+        "lastModified": 1785306675,
+        "narHash": "sha256-iKP24/oSawYLGnDdpmf1raQgn6dnYgcsbLqqzBtx5l0=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "5c3538a897d6e36e76722bb103fa290012324b55",
+        "rev": "f279d4333f549c84c6c15ec73e8e2ab26469c5e6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785306675,
-        "narHash": "sha256-iKP24/oSawYLGnDdpmf1raQgn6dnYgcsbLqqzBtx5l0=",
+        "lastModified": 1785349888,
+        "narHash": "sha256-yFrYZQoQlcx7CsugeiYlFu55+cWdRUD1C1c9hPh2IRs=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "f279d4333f549c84c6c15ec73e8e2ab26469c5e6",
+        "rev": "5834293e8f53eb07ddd891191f2b32d62747406a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785349888,
-        "narHash": "sha256-yFrYZQoQlcx7CsugeiYlFu55+cWdRUD1C1c9hPh2IRs=",
+        "lastModified": 1785350324,
+        "narHash": "sha256-I35D6HMilNcNxa/7mlr5mkfA5QzkGNvltRSzyDmi2pE=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "5834293e8f53eb07ddd891191f2b32d62747406a",
+        "rev": "a85946697251bbfeaebb514b36952831c4c3cdda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pins Hermes P7 for deploy point D7.\n\nThis adds the durable lifecycle audit log, bounded Temporary Capability Grants, and Telegram start/result notifications for automatic execution.\n\nValidation:\n- legion-node3 system derivation evaluates to /nix/store/zm3fzni4gy73i81giskbn4zj0hdnsv16-nixos-system-legion-node3-26.11.20260718.61b7c44.drv\n- repository pre-commit checks pass\n\nDeployment remains explicitly gated. This PR does not activate legion-node3.