### PR TITLE
chore(hermes): pin brokered reminders

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785353681,
-        "narHash": "sha256-nkdDbJ8FVPl4tugAg6tmbHcDPPp0ZC1nWkaBIZ2BzjE=",
+        "lastModified": 1785354459,
+        "narHash": "sha256-5LlRUL1ZM8VhUWeXq98hd7PvZR9If9+qAkGTu96yZmY=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "0396e2c56ea106af418ce954f82e2f115a6f37f3",
+        "rev": "1af79452490194c1bb93ebd61f2449c9cdfa81dd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785351226,
-        "narHash": "sha256-pOEsbrX54WD84SCPJ64nm0NodD3BHxcMIjvSzWOGOT8=",
+        "lastModified": 1785352411,
+        "narHash": "sha256-aVb70zJo8b6vHhqeW04KZA+Cy1gxHy/zmC2X64dKqzY=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "832db863eda2d72e99b40ae3d1aa19a8051557a9",
+        "rev": "c100ff86584ab3da91613ee97c313ba0fbfbcec9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785309323,
-        "narHash": "sha256-lRe3MWQc3JxfjqhC2CyTPguSp3okbKbY5daEIDBbfD0=",
+        "lastModified": 1785351226,
+        "narHash": "sha256-pOEsbrX54WD84SCPJ64nm0NodD3BHxcMIjvSzWOGOT8=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "4aef8744c25b49fa2ae8a8452a6752c222fd558b",
+        "rev": "832db863eda2d72e99b40ae3d1aa19a8051557a9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785306675,
-        "narHash": "sha256-iKP24/oSawYLGnDdpmf1raQgn6dnYgcsbLqqzBtx5l0=",
+        "lastModified": 1785309323,
+        "narHash": "sha256-lRe3MWQc3JxfjqhC2CyTPguSp3okbKbY5daEIDBbfD0=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "f279d4333f549c84c6c15ec73e8e2ab26469c5e6",
+        "rev": "4aef8744c25b49fa2ae8a8452a6752c222fd558b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785352411,
-        "narHash": "sha256-aVb70zJo8b6vHhqeW04KZA+Cy1gxHy/zmC2X64dKqzY=",
+        "lastModified": 1785352830,
+        "narHash": "sha256-LL+LnUp9bPWfMQq8V8lxNXE30v9lv4B0fuU1sD+UxCA=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "c100ff86584ab3da91613ee97c313ba0fbfbcec9",
+        "rev": "6680c4c2dd910c567de4f08d6bb31ac95e712e09",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785352830,
-        "narHash": "sha256-LL+LnUp9bPWfMQq8V8lxNXE30v9lv4B0fuU1sD+UxCA=",
+        "lastModified": 1785353681,
+        "narHash": "sha256-nkdDbJ8FVPl4tugAg6tmbHcDPPp0ZC1nWkaBIZ2BzjE=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "6680c4c2dd910c567de4f08d6bb31ac95e712e09",
+        "rev": "0396e2c56ea106af418ce954f82e2f115a6f37f3",
         "type": "github"
       },
       "original": {

--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -422,6 +422,10 @@ in {
               imports = [inputs.hermes-agent-config.nixosModules.hermes];
               hermes = {
                 metricsUrl = "http://${monitoringNode.privateIPv4}:8428";
+                legacyScheduledJobIds = [
+                  "fd51c8b345d4"
+                  "2ca208a771ed"
+                ];
               };
               # Ownership requirements moved here with the secrets: the
               # extracted module now takes secret paths instead of owning


### PR DESCRIPTION
Stacks D8 on the D7 deployment pin and advances only the hermes-agent-config lock entry to PR #26 commit 4aef874.\n\nValidated without deployment:\n- node3 NixOS system evaluation: /nix/store/bfpnrv7l98ay09i6q47qbzcw3lgwv96m-nixos-system-legion-node3-26.11.20260718.61b7c44.drv\n- reminder socket evaluates broker-owned at mode 0600\n- reminder runner evaluates with the restricted reminder Codex home and pinned Hermes/Codex binaries\n- treefmt and pre-commit checks pass\n\nNo service was activated and no production state was changed.