### PR TITLE
chore(hermes): pin network hardening

### DIFF
--- a/docs/runbooks/hermes-approval-migration.md
+++ b/docs/runbooks/hermes-approval-migration.md
@@ -21,9 +21,10 @@ without a separate explicit confirmation.
 8. As Hermes and `hermes-command`, create and edit files and Git metadata
     beneath `/mnt/hermes/worktrees`; confirm each identity can modify the
     other's files.
-9. Confirm ordinary public GET requests work while private addresses, local
-    binding, mutating methods, protected files, and direct Nix daemon access
-    fail.
+9. Confirm public Internet requests and the named VictoriaMetrics endpoint
+    work. Confirm loopback, metadata, an unlisted private address, local
+    binding, protected files, and direct agent access to the Nix daemon fail.
+    Repeat the network checks with IPv4, IPv6, redirects, and IPv4-mapped IPv6.
 10. Approve a bounded command and a Nix command. Confirm one-shot execution,
     status, cancellation, timeout, 64 KiB output limits, serialization, and the
     500 MiB systemd memory limit.

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785357753,
-        "narHash": "sha256-gSk8vxfgZds6QSoUS+CgW1j+F9Nx809d04D1RRjq/Es=",
+        "lastModified": 1785358218,
+        "narHash": "sha256-lofDlS+K2NwK+HZs5LyohA+CTqucX38YUmWD3XXr1Cw=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "7b9f4b70fdf4e9031b389db122de35989f153815",
+        "rev": "5713e19dbb0b3fa67775f610457d8a4b3d49e2fc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785357444,
-        "narHash": "sha256-nMjuJtGu+egqn6fC8+uMlQyuxPCrQ3g0w45rCrXRHBc=",
+        "lastModified": 1785357753,
+        "narHash": "sha256-gSk8vxfgZds6QSoUS+CgW1j+F9Nx809d04D1RRjq/Es=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "3aa6af5bdafa639c2cf0a844368dce71a4a5c727",
+        "rev": "7b9f4b70fdf4e9031b389db122de35989f153815",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785357127,
-        "narHash": "sha256-Op4CGDrCCXohXq4OZt1f2hKlfaZRJu2/GYHmUCGVOPk=",
+        "lastModified": 1785357444,
+        "narHash": "sha256-nMjuJtGu+egqn6fC8+uMlQyuxPCrQ3g0w45rCrXRHBc=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "7caa2b1ea790b008c217265299fa6d5b0d2a649b",
+        "rev": "3aa6af5bdafa639c2cf0a844368dce71a4a5c727",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785309323,
-        "narHash": "sha256-lRe3MWQc3JxfjqhC2CyTPguSp3okbKbY5daEIDBbfD0=",
+        "lastModified": 1785311210,
+        "narHash": "sha256-csmnOpiNGxbgjT9MxkthU1x1+vLozYnff180T/5tN4o=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "4aef8744c25b49fa2ae8a8452a6752c222fd558b",
+        "rev": "cb1b71c07b8510d5a858a84c24ed367fed7555e7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1785358218,
-        "narHash": "sha256-lofDlS+K2NwK+HZs5LyohA+CTqucX38YUmWD3XXr1Cw=",
+        "lastModified": 1785361742,
+        "narHash": "sha256-+zRw5StJjFpltK5y7+oy80bXz0/DdgeoxPxh9mwFYxE=",
         "owner": "jeiang",
         "repo": "hermes-agent-config",
-        "rev": "5713e19dbb0b3fa67775f610457d8a4b3d49e2fc",
+        "rev": "5ae285bccb53b013592ebdb79b4bd9f627055db1",
         "type": "github"
       },
       "original": {

--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -422,6 +422,14 @@ in {
               imports = [inputs.hermes-agent-config.nixosModules.hermes];
               hermes = {
                 metricsUrl = "http://${monitoringNode.privateIPv4}:8428";
+                network.privateEndpoints.victoriametrics = {
+                  address = monitoringNode.privateIPv4;
+                  port = 8428;
+                  units = [
+                    "agent"
+                    "command-runner"
+                  ];
+                };
               };
               # Ownership requirements moved here with the secrets: the
               # extracted module now takes secret paths instead of owning


### PR DESCRIPTION
## Summary
- pin hermes-agent-config P9 at cb1b71c07b8510d5a858a84c24ed367fed7555e7
- expose only VictoriaMetrics at the inventory-derived 172.17.0.3:8428 endpoint to the agent and approved command runner
- correct the live acceptance runbook: IP policy does not restrict HTTP methods

## Validation
- nix fmt -- --fail-on-change
- nix flake check --keep-going (host-incompatible package/dev-shell failures remain ignored by the flake checker)
- legion-node3 system derivation: /nix/store/ddwiazdpgn52a0l7bbb2rxgyx0fdmi3g-nixos-system-legion-node3-26.11.20260718.61b7c44.drv
- evaluated Hermes and runner IPAddressAllow lists are empty
- evaluated fixed proxy allows only 172.17.0.3/32 and runs systemd-socket-proxyd 172.17.0.3:8428
- reminder runner masks the VictoriaMetrics Unix socket

## Deployment
No deployment performed. D9 requires explicit authorization and live public/private/metadata/DNS/IPv6/VictoriaMetrics checks on legion-node3. Roll back by restoring the D8 input pin.