### PR TITLE
feat(artemis): serve Ornith-1.0-9B via llama-swap on 8080

### DIFF
--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -31,6 +31,7 @@
         self.nixosModules.vr
         self.nixosModules.gaming
         self.nixosModules.impermanence
+        self.nixosModules.llama-swap
 
         # disks
         self.diskoConfigurations.artemis

--- a/modules/nixos/llama-swap.nix
+++ b/modules/nixos/llama-swap.nix
@@ -45,13 +45,19 @@ _: {
       };
     };
 
-    systemd.services.llama-swap.serviceConfig = {
-      # GPU render-node access for the DynamicUser the upstream unit runs as.
-      SupplementaryGroups = ["render" "video"];
-      # Writable RADV shader cache; disposable state, fine for nukeRoot to
-      # wipe on reboot.
-      CacheDirectory = "llama-swap";
+    systemd.services.llama-swap = {
+      # rocm-smi on PATH gives llama-swap's UI VRAM/temperature stats -- it
+      # probes LACT, nvidia-smi, then rocm-smi (v224 has no sysfs fallback).
+      # The standalone sysfs reader, not the full ROCm stack.
+      path = [pkgs.rocmPackages.rocm-smi];
+      serviceConfig = {
+        # GPU render-node access for the DynamicUser the upstream unit runs as.
+        SupplementaryGroups = ["render" "video"];
+        # Writable RADV shader cache; disposable state, fine for nukeRoot to
+        # wipe on reboot.
+        CacheDirectory = "llama-swap";
+      };
+      environment.XDG_CACHE_HOME = "/var/cache/llama-swap";
     };
-    systemd.services.llama-swap.environment.XDG_CACHE_HOME = "/var/cache/llama-swap";
   };
 }

--- a/modules/nixos/llama-swap.nix
+++ b/modules/nixos/llama-swap.nix
@@ -1,0 +1,57 @@
+_: {
+  # Ornith-1.0-9B (Q6_K) served locally on artemis, fronted by llama-swap so
+  # VRAM is freed after idle instead of holding the model resident forever.
+  flake.nixosModules.llama-swap = {
+    pkgs,
+    lib,
+    ...
+  }: let
+    llama-cpp = pkgs.llama-cpp.override {vulkanSupport = true;};
+    llama-server = lib.getExe' llama-cpp "llama-server";
+    # Ornith-1.0-9B Q6_K, hash-pinned into the store so it survives
+    # reboots (nix store is persisted) with no impermanence entry.
+    model = pkgs.fetchurl {
+      url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF/resolve/main/ornith-1.0-9b-Q6_K.gguf";
+      hash = "sha256-M7b2o+PwUHhDjhLfiktVyKz3jOrcxjnSrxzzWgJug4c=";
+    };
+  in {
+    services.llama-swap = {
+      enable = true;
+      # Bind all interfaces; the firewall (not the listen address) is what
+      # keeps this off the LAN -- see openFirewall below.
+      listenAddress = "0.0.0.0";
+      port = 8080;
+      # openFirewall stays at its false default. artemis trusts the netbird
+      # interface (modules/nixos/netbird.nix), so with the firewall closed
+      # this is reachable from localhost and the netbird mesh, but blocked
+      # from the LAN.
+      settings = {
+        # Model load (7.4 GB, full GPU offload) can take longer than
+        # llama-swap's default health-check timeout.
+        healthCheckTimeout = 300;
+        models."ornith-1.0-9b" = {
+          # ${PORT} above is llama-swap's own macro (escaped with the extra
+          # $ so Nix leaves it literal in the generated YAML), not a Nix
+          # interpolation like ${llama-server}/${model} below.
+          # -ngl 99: full GPU offload. -c 32768: ~12 GB of the 16 GB VRAM
+          # budget at this quant. --jinja: use the model's embedded chat
+          # template (Ornith is Qwen 3.5-based). --temp/--top-p/--top-k:
+          # sampling defaults per the Ornith-1.0-9B model card.
+          cmd = "${llama-server} --port \${PORT} -m ${model} -ngl 99 -c 32768 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
+          aliases = ["ornith"];
+          # Free all VRAM after 30 min idle.
+          ttl = 1800;
+        };
+      };
+    };
+
+    systemd.services.llama-swap.serviceConfig = {
+      # GPU render-node access for the DynamicUser the upstream unit runs as.
+      SupplementaryGroups = ["render" "video"];
+      # Writable RADV shader cache; disposable state, fine for nukeRoot to
+      # wipe on reboot.
+      CacheDirectory = "llama-swap";
+    };
+    systemd.services.llama-swap.environment.XDG_CACHE_HOME = "/var/cache/llama-swap";
+  };
+}


### PR DESCRIPTION
## Summary

- New `modules/nixos/llama-swap.nix`: llama-swap fronts a Vulkan-accelerated `llama-server` (nixpkgs `llama-cpp` b9925, `vulkanSupport = true`) serving **Ornith-1.0-9B Q6_K**, hash-pinned into the store via `fetchurl` — no impermanence entry, no migrate-persist step, no secrets.
- Imported by `artemisConfiguration` only.
- **Exposure**: bound to `0.0.0.0:8080` with `openFirewall = false` — reachable from localhost and the netbird mesh (trusted interface), blocked from the LAN. Keyless by design (private mesh only).
- **VRAM lifecycle**: llama-swap spawns `llama-server` on first request and unloads it after **30 min idle** (`ttl = 1800`), freeing all VRAM on the shared gaming/VR GPU.
- **Server flags**: full GPU offload, 32K context (~12 GB of 16 GB VRAM), `--jinja` for the embedded Qwen 3.5 chat template (reasoning model), sampling defaults from the model card (`temp 0.6, top-p 0.95, top-k 20`).
- Unit fixups on the hardened upstream `DynamicUser` service: `SupplementaryGroups = ["render" "video"]` for GPU node access, plus a writable RADV shader cache under `/var/cache/llama-swap`.

## Validation

- `just fmt` clean; pre-commit hooks (editorconfig-checker, statix, treefmt) passed.
- `just check` hits the pre-existing "no x86_64-linux builder on this Mac" limitation (reproduced identically on clean baseline); eval-level checks of the artemis closure passed instead: literal `${PORT}` macro in the generated llama-swap YAML, resolved store paths for model and server, port 8080 absent from `allowedTCPPorts`.
- SRI hash independently recomputed from the Hugging Face LFS sha256.

## Post-deploy verification (before merge)

First build downloads the 7.4 GB model (CI's next toplevel build will too, landing it in the attic cache).

- [ ] `curl http://localhost:8080/v1/models` on artemis
- [ ] Same via the netbird address; LAN address refused
- [ ] `POST /v1/chat/completions` with `"model": "ornith"` returns a GPU-generated completion
- [ ] Chat web UI at `/upstream/ornith-1.0-9b/` (status page at `/`)
- [ ] VRAM freed ~30 min after last request

If `llama-server` can't enumerate the GPU on first spawn (`journalctl -u llama-swap`), the agreed fallback is loosening `PrivateUsers`/`MemoryDenyWriteExecute` on the unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)