### PR TITLE
fix(hermes): install SOUL.md where the runtime reads it; make kb-sync actually fire

### DIFF
--- a/modules/nixos/hermes/SOUL.md
+++ b/modules/nixos/hermes/SOUL.md
@@ -1,12 +1,12 @@
 # SOUL.md
 
-> **This file is Nix-managed.** It is installed fresh into your workspace on
-> every deploy (`services.hermes-agent.documents` in
-> `modules/nixos/hermes/default.nix`), overwriting whatever is here. Edits
-> you make to this file directly will NOT persist past the next deploy. If
-> something here should change, it goes through the `cornn-flaek` repo (this
-> file's source lives at `modules/nixos/hermes/SOUL.md`), not through you
-> editing it in place.
+> **This file is Nix-managed.** It is installed fresh to
+> `~/.hermes/SOUL.md` on every service start (the `hermes-agent` preStart
+> in `modules/nixos/hermes/default.nix`), overwriting whatever is here.
+> Edits you make to this file directly will NOT persist past the next
+> restart. If something here should change, it goes through the
+> `cornn-flaek` repo (this file's source lives at
+> `modules/nixos/hermes/SOUL.md`), not through you editing it in place.
 >
 > Durable knowledge that IS yours to write belongs in `knowledge-base/`
 > instead -- see "Knowledge discipline" below.
@@ -20,8 +20,10 @@ running NixOS, deployed from the `cornn-flaek` repo.
 ## Knowledge discipline
 
 Durable knowledge -- anything you'd want to remember across sessions, or
-that's useful to look back on later -- goes in `knowledge-base/` as
-markdown, not in this file and not only in your own session memory. A
+that's useful to look back on later -- goes in
+`/var/lib/hermes/workspace/knowledge-base/` (a clone of
+`jeiang/knowledge-base`) as markdown, not in this file and not only in
+your own session memory or `~/.hermes/memories/`. A
 system timer (`hermes-kb-sync`) auto-commits and pushes that directory to
 its GitHub remote every 15 minutes, so you don't have to remember to sync
 it yourself. But for anything important, feel free to `git commit` and
@@ -31,7 +33,7 @@ credentials are already configured (`gh` is authenticated via
 
 ## Fleet awareness
 
-See `SERVERS.md` (colocated with this file, same Nix-managed caveat) for
+See `/var/lib/hermes/workspace/SERVERS.md` (same Nix-managed caveat) for
 the fleet layout and how to query metrics (VictoriaMetrics) and logs
 (VictoriaLogs) from any node.
 

--- a/modules/nixos/hermes/default.nix
+++ b/modules/nixos/hermes/default.nix
@@ -86,13 +86,19 @@
         agent.reasoning_effort = "medium";
       };
 
-      # SOUL.md/SERVERS.md are colocated with this module (documents values
-      # may be paths -- nix/nixosModules.nix `documentDerivation`) and get
+      # SERVERS.md is colocated with this module (documents values may be
+      # paths -- nix/nixosModules.nix `documentDerivation`) and gets
       # installed fresh into workingDirectory on EVERY activation, so
-      # in-place self-edits by the agent never persist; see the note at the
-      # top of SOUL.md.
+      # in-place self-edits by the agent never persist.
+      #
+      # SOUL.md is NOT wired through `documents`: that option only drops
+      # files into workingDirectory, but the runtime loads its persona from
+      # `$HERMES_HOME/SOUL.md` = `${cfg.stateDir}/.hermes/SOUL.md`
+      # (agent/prompt_builder.py `load_soul_md()` at the pinned rev) and
+      # seeds DEFAULT_SOUL_MD there on first run -- a SOUL.md in the
+      # workspace is inert. Ours is installed to the real path by the
+      # preStart script below.
       documents = {
-        "SOUL.md" = ./SOUL.md;
         "SERVERS.md" = ./SERVERS.md;
       };
 
@@ -192,6 +198,12 @@
             if [ ! -f "${codexAuthPath}" ]; then
               install -m 0600 "${config.sops.secrets."hermes/codex-auth.json".path}" "${codexAuthPath}"
             fi
+
+            # Persona: overwrite unconditionally (Nix-managed, see the note
+            # at the top of SOUL.md) at the path the runtime actually reads
+            # -- see the `documents` comment above for why this can't go
+            # through that option.
+            install -m 0640 ${./SOUL.md} "${cfg.stateDir}/.hermes/SOUL.md"
           '';
 
           # legion-node3 also runs the memory-constrained monitoring stack
@@ -226,7 +238,7 @@
           serviceConfig = {
             Type = "oneshot";
             User = cfg.user;
-            inherit (cfg) group;
+            Group = cfg.group;
             # GITHUB_TOKEN, read by `gh` below as a non-interactive
             # credential source (gh auto-detects GITHUB_TOKEN/GH_TOKEN
             # from its environment -- no `gh auth login` needed on this
@@ -276,8 +288,15 @@
       timers.hermes-kb-sync = {
         wantedBy = ["timers.target"];
         timerConfig = {
+          # OnUnitActiveSec alone never fires on a service that has never
+          # been active (there is no "last activation" to be relative to),
+          # so the sync -- including the initial clone -- would never run.
+          # OnActiveSec schedules the first run relative to the timer's own
+          # activation (every boot, and any deploy that restarts the timer);
+          # OnUnitActiveSec keeps the 15m cadence after that. Persistent=
+          # was dropped: it only applies to OnCalendar= timers.
+          OnActiveSec = "1m";
           OnUnitActiveSec = "15m";
-          Persistent = true;
         };
       };
     };


### PR DESCRIPTION
## Problem

Hermes claimed it recorded self-improvements, but the knowledge base had no commits — and when asked, it quoted the generic upstream default SOUL.md, not ours.

Three separate defects in `modules/nixos/hermes/default.nix`:

1. **Custom SOUL.md never reached the agent.** `services.hermes-agent.documents` only installs files into `workingDirectory` (the workspace), but the runtime loads its persona from `$HERMES_HOME/SOUL.md` = `/var/lib/hermes/.hermes/SOUL.md` (`agent/prompt_builder.py` `load_soul_md()` at the pinned rev) and seeds `DEFAULT_SOUL_MD` there on first run. The agent has been running persona-less, so it never knew about the KB discipline and wrote "memories" to `~/.hermes/memories/` instead.
2. **`hermes-kb-sync.timer` never fired once.** `OnUnitActiveSec=` is relative to the service's last activation; a never-run service has none, so with no other trigger nothing was ever scheduled (`Trigger: n/a` on the node). The initial `git clone` lives in that unit, so the KB clone doesn't exist on the node at all.
3. **`inherit (cfg) group;` in `serviceConfig`** emitted lowercase `group`, which systemd logs as "Unknown key" and ignores.

## Fix

- Install SOUL.md to `${cfg.stateDir}/.hermes/SOUL.md` (overwrite-always) in the existing `hermes-agent` preStart; `documents` keeps only SERVERS.md.
- Add `OnActiveSec = "1m"` so the first sync fires a minute after the timer starts (boot, or this deploy restarting the changed timer); drop `Persistent=` (OnCalendar-only). `OnUnitActiveSec=15m` keeps the cadence after.
- `Group = cfg.group;`.
- SOUL.md text updated: real install path, absolute KB path (`/var/lib/hermes/workspace/knowledge-base/`), SERVERS.md's actual location.

## Validation

- Pure eval of `legion-node3` `system.build.toplevel` passes.
- Generated units confirmed via `nix eval`: timer has `OnActiveSec=1m` + `OnUnitActiveSec=15m`, sync unit has `Group=hermes`, preStart installs SOUL.md to `/var/lib/hermes/.hermes/SOUL.md`.
- treefmt/statix/editorconfig hooks pass.

## Post-deploy verify (`just deploy legion-node3 -s --remote-build`)

- `journalctl -u hermes-kb-sync` shows the clone within ~1 min; a commit lands in `jeiang/knowledge-base` within 15 min of the agent writing there.
- Asking Hermes for its SOUL.md returns the Aidan persona.
- Anything worth keeping in `/var/lib/hermes/.hermes/memories/` can then be asked into the KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)