### PR TITLE
feat(hermes): run gpt-5.6-luna at high reasoning effort with fast mode

### DIFF
--- a/modules/nixos/hermes/default.nix
+++ b/modules/nixos/hermes/default.nix
@@ -83,7 +83,17 @@
           # can't persist past a deploy.
           openai_runtime = "auto";
         };
-        agent.reasoning_effort = "medium";
+        agent = {
+          reasoning_effort = "high";
+          # OpenAI Priority Processing ("fast mode"). The gateway maps
+          # "fast" -> service_tier=priority (gateway/run.py
+          # `_load_service_tier` at the pinned rev), and gpt-5.6-luna is
+          # fast-eligible (hermes_cli/models.py `_is_openai_fast_model`:
+          # gpt-* prefix, non-codex). Declared here so every activation
+          # re-asserts it over any `/fast --global` runtime toggle, same
+          # reasoning as `openai_runtime` above.
+          service_tier = "fast";
+        };
       };
 
       # SERVERS.md is colocated with this module (documents values may be


### PR DESCRIPTION
Switches Hermes from luna at medium effort / normal speed to **high** reasoning effort with **fast mode** (OpenAI Priority Processing).

- `agent.reasoning_effort = "high"`
- `agent.service_tier = "fast"` — the exact key `/fast --global` persists; the gateway maps it to `service_tier=priority` (`gateway/run.py` `_load_service_tier` at the pinned rev) and the codex transport forwards it to the backend
- Model id unchanged: there is no `-fast` luna slug; `gpt-5.6-luna` is fast-eligible upstream (`hermes_cli/models.py` `_is_openai_fast_model`: `gpt-` prefix, non-codex)
- Declared in Nix so every activation re-asserts it over runtime `/fast` toggles, same reasoning as the existing `openai_runtime` pin

Verified: `nix eval .#nixosConfigurations.legion-node3.config.services.hermes-agent.settings` renders `{"agent":{"reasoning_effort":"high","service_tier":"fast"},...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)