### PR TITLE
feat(darwin): expand zakkart macOS preferences and fix fish direnv loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Zakkart: a nix-darwin host for the macOS workstation (`modules/hosts/zakkart/`, `modules/darwin/`), managed with Determinate Nix (ADR 0008) and nixpkgs-first application sourcing with Homebrew/App Store exceptions (ADR 0009). Includes a `just darwin-switch` recipe, a `checks.aarch64-darwin.zakkart-system` CI check built on a hosted macOS runner, and `docs/runbooks/zakkart-bootstrap.md`.
+- Zakkart macOS preferences (`modules/darwin/preferences.nix`): dock moved right with autohide and hot corners, menu bar mirroring the observed macOS 26 values, pink accent/highlight colors, the application firewall, the repo's `assets/wallpaper.jpg`, Helium as the default browser via `defaultbrowser`, the built-in display scaled to "More Space" via `displayplacer`, and the Spotlight (Cmd+Space) hotkey disabled — per `docs/adr/0010-script-user-scoped-macos-preferences-nix-darwin-cannot-express.md`.
 
 ### Fixed
 
@@ -13,3 +14,4 @@
 - Declare `trusted: true` on every Brewfile tap entry so Homebrew >= 6.0's tap-trust enforcement doesn't refuse to load formulae/casks from the pinned third-party taps (`netbirdio/tap`, `can1357/tap`, `k06a/tap`) during activation.
 - Move the host toolbox out of the wrapped Fish shell and use Cachix's pinned binary package to avoid IFD evaluation.
 - Replace the pinned-store-path Cachix package (`builtins.storePath`, impure) with nixpkgs' `pkgs.cachix` — the pinned paths were old Hydra builds of the same 1.11.1 `-bin` output already cached on cache.nixos.org — and drop `--impure` from CI now that nothing violates pure evaluation.
+- Export `DIRENV_CONFIG` in the wrapped fish's darwin login shells -- the wrapped fish never sourced nix-darwin's `set-environment`, so nix-direnv's loader (`/etc/direnv/direnvrc`) never loaded and `use flake` silently fell back to direnv's builtin, uncached implementation, re-evaluating dev shells on every prompt.

--- a/docs/adr/0010-script-user-scoped-macos-preferences-nix-darwin-cannot-express.md
+++ b/docs/adr/0010-script-user-scoped-macos-preferences-nix-darwin-cannot-express.md
@@ -1,0 +1,50 @@
+# Script user-scoped macOS preferences nix-darwin cannot express
+
+Zakkart's desktop preferences (`modules/darwin/preferences.nix`) use
+`system.defaults` wherever the pinned nix-darwin rev has an option that
+writes the same value macOS itself reads: dock placement/autohide/hot
+corners, the menu bar clock, `controlcenter.BatteryShowPercentage`, and the
+pink accent/highlight colors via `CustomUserPreferences.NSGlobalDomain`.
+Everything else is scripted in `system.activationScripts.postActivation.text`
+using nix-darwin's own user-context pattern (`launchctl asuser "$(id -u --
+<user>)" sudo --user=<user> -- <cmd>`, since all activation otherwise runs as
+root and `postUserActivation` was removed from this rev): the three menu bar
+`controlcenter` items nix-darwin can't express faithfully, the Spotlight
+(Cmd+Space) symbolic hotkey, the wallpaper, the default browser, and the
+built-in display's scaled resolution. `controlcenter.Bluetooth` is the
+clearest case for scripting over the option: the pinned nix-darwin writes the
+pre-macOS-26 constant (18) for that option, not the value macOS 26 actually
+reads at `-currentHost` (2) — using the option would silently converge to
+the wrong menu bar state on every activation. Steps that touch TCC consent,
+LaunchServices, or WindowServer (wallpaper via System Events automation,
+default browser, display scaling) warn and continue on failure rather than
+aborting activation, since a denied or not-yet-granted consent dialog isn't
+a configuration error; the deterministic `defaults` writes still fail loudly
+under activation's `set -e`. One-time TCC and default-browser confirmation
+dialogs on first activation (or after a TCC reset) are accepted as an
+expected side effect. Night Shift is deliberately left unmanaged: its
+schedule lives in a private CoreBrightness plist format with no documented
+`defaults` keys, so scripting it would mean reverse-engineering an
+undocumented binary format for a single toggle.
+
+## Consequences
+
+- A TCC reset (or a fresh machine) re-prompts for System Events automation
+  and default-browser consent on the next activation; that's expected, not a
+  bug.
+- The observed constants this ADR hardcodes (`Bluetooth = 2`, `Spotlight =
+  8`, `Weather = 2`, hotkey `64`) are macOS 26 values verified live on this
+  machine; a future macOS major can change them, and the fix is to
+  re-observe and update the activation script, not to expect nix-darwin's
+  options to catch up.
+- These steps converge state on every activation rather than enforcing it
+  continuously — a user can change any of them by hand between activations,
+  and the next `darwin-switch` will silently reassert the declared value.
+- Activation stays non-interactive-safe: no step blocks on a dialog, and a
+  denied consent degrades to a warning instead of failing the whole switch.
+- Night Shift stays a manual, undeclared setting; it won't survive a fresh
+  machine bootstrap.
+
+## References
+
+- Homebrew fallback policy for `displayplacer`: `docs/adr/0009-source-macos-applications-nixpkgs-first-with-declared-exceptions.md`.

--- a/modules/darwin/apps.nix
+++ b/modules/darwin/apps.nix
@@ -26,6 +26,7 @@
         # CLI
         bat
         btop
+        defaultbrowser
         erdtree
         # withWhisper defaults on for ffmpeg-full >=8.0 (whisper speech
         # recognition support); whisper-cpp's CoreML backend fails to link

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -93,6 +93,11 @@
         # homebrew-core (Formula/m/mole.rb, tw93/Mole -- same Mac cleanup
         # tool), so it doesn't need a tap.
         "mole"
+        # Not packaged in nixpkgs for darwin (ADR 0009 exception); a plain
+        # "displayplacer" formula exists in the pinned homebrew-core
+        # (Formula/d/displayplacer.rb v1.4.0, arm64_tahoe bottle), so it
+        # doesn't need a tap either.
+        "displayplacer"
       ];
 
       # App Store IDs verified against the apps.apple.com Mac listings.

--- a/modules/darwin/preferences.nix
+++ b/modules/darwin/preferences.nix
@@ -79,13 +79,13 @@ _: {
         # closed) or it's already at the target resolution; never fails
         # activation, since persistent screen ids can shift with topology.
         if [ -x /opt/homebrew/bin/displayplacer ]; then
-          displayList=$(${asUser "/opt/homebrew/bin/displayplacer list"})
+          displayList=$(${asUser "/opt/homebrew/bin/displayplacer list"} 2>/dev/null) || displayList=""
           builtinId=$(echo "$displayList" | awk '
             /Persistent screen id:/ { id = $NF }
             /built in screen/ { print id; exit }
           ')
           if [ -z "$builtinId" ]; then
-            echo "zakkart preferences: no built-in screen reported (lid closed?), skipping display scaling"
+            echo "zakkart preferences: no built-in screen reported or displayplacer list failed (lid closed? no WindowServer session?), skipping display scaling"
           else
             currentRes=$(echo "$displayList" | awk -v want="$builtinId" '
               /Persistent screen id:/ { id = $NF }

--- a/modules/darwin/preferences.nix
+++ b/modules/darwin/preferences.nix
@@ -1,0 +1,105 @@
+# Desktop preferences for zakkart. Everything nix-darwin's system.defaults
+# can express faithfully lives there; everything else (menu bar items whose
+# nix-darwin option writes stale pre-macOS-26 values, the Spotlight hotkey,
+# wallpaper, default browser, display scaling) is scripted as idempotent
+# user-context activation steps instead. Policy and rationale: docs/adr/0010.
+_: {
+  flake.darwinModules.preferences = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    userArg = lib.escapeShellArg config.preferences.user.name;
+    asUser = cmd: ''launchctl asuser "$(id -u -- ${userArg})" sudo --user=${userArg} -- ${cmd}'';
+    wallpaper = ../../assets/wallpaper.jpg;
+    defaultbrowser = lib.getExe pkgs.defaultbrowser;
+  in {
+    system = {
+      defaults = {
+        dock = {
+          autohide = true;
+          orientation = "right";
+          # BL = App Windows, BR = Mission Control, TR = Notification Center.
+          wvous-bl-corner = 3;
+          wvous-br-corner = 2;
+          wvous-tr-corner = 12;
+        };
+
+        menuExtraClock = {
+          ShowDayOfWeek = true;
+          ShowAMPM = false;
+          ShowDate = 0;
+        };
+
+        controlcenter.BatteryShowPercentage = false;
+
+        CustomUserPreferences.NSGlobalDomain = {
+          AppleAccentColor = 6;
+          AppleHighlightColor = "1.000000 0.749020 0.823529 Pink";
+        };
+      };
+
+      # Failure policy (ADR 0010): deterministic `defaults` writes fail
+      # loudly (activation runs under `set -e`); steps that touch TCC
+      # consent, LaunchServices, or WindowServer warn and continue instead,
+      # since those can be denied or unavailable (lid closed, consent not
+      # yet granted) without that being a configuration error.
+      activationScripts.postActivation.text = ''
+        # Menu bar: -currentHost mirrors the observed macOS 26 values.
+        # nix-darwin's own controlcenter.Bluetooth option writes the
+        # pre-macOS-26 constant (18), not the observed value (2), so these are
+        # scripted instead of expressed via system.defaults.
+        ${asUser "defaults -currentHost write com.apple.controlcenter Bluetooth -int 2"}
+        ${asUser "defaults -currentHost write com.apple.controlcenter Spotlight -int 8"}
+        ${asUser "defaults -currentHost write com.apple.controlcenter Weather -int 2"}
+        killall -qu ${userArg} ControlCenter || true
+
+        # Spotlight (Cmd+Space): disable symbolic hotkey 64 only, via a
+        # merge-safe -dict-add so other AppleSymbolicHotKeys entries survive
+        # (CustomUserPreferences would clobber the whole dict).
+        ${asUser "defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 \"<dict><key>enabled</key><false/></dict>\""}
+        ${asUser "/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u"} || true
+
+        # Wallpaper: TCC (System Events automation) consent may be denied on
+        # first run, so warn instead of failing activation.
+        ${asUser "osascript -e 'tell application \"System Events\" to set picture of every desktop to POSIX file \"${wallpaper}\"'"} \
+          || echo >&2 "warning: failed to set wallpaper (System Events automation consent?)"
+
+        # Default browser: only touch LaunchServices (one-time consent dialog)
+        # if Helium isn't already the default.
+        if ! ${asUser defaultbrowser} | grep -q '^\* helium$'; then
+          ${asUser "${defaultbrowser} helium"} \
+            || echo >&2 "warning: failed to set default browser to Helium"
+        fi
+
+        # Display "More Space": scale the built-in display to 1800x1169 via
+        # displayplacer (ADR 0009 Homebrew exception; not packaged in nixpkgs
+        # for darwin). Skipped when no built-in screen is reported (lid
+        # closed) or it's already at the target resolution; never fails
+        # activation, since persistent screen ids can shift with topology.
+        if [ -x /opt/homebrew/bin/displayplacer ]; then
+          displayList=$(${asUser "/opt/homebrew/bin/displayplacer list"})
+          builtinId=$(echo "$displayList" | awk '
+            /Persistent screen id:/ { id = $NF }
+            /built in screen/ { print id; exit }
+          ')
+          if [ -z "$builtinId" ]; then
+            echo "zakkart preferences: no built-in screen reported (lid closed?), skipping display scaling"
+          else
+            currentRes=$(echo "$displayList" | awk -v want="$builtinId" '
+              /Persistent screen id:/ { id = $NF }
+              id == want && /Resolution:/ { print $NF; exit }
+            ')
+            if [ "$currentRes" = "1800x1169" ]; then
+              echo "zakkart preferences: built-in display already at 1800x1169, skipping"
+            else
+              ${asUser "/opt/homebrew/bin/displayplacer \"id:$builtinId res:1800x1169 scaling:on degree:0\""} \
+                || echo >&2 "warning: failed to set built-in display resolution"
+            fi
+          fi
+        fi
+      '';
+    };
+  };
+}

--- a/modules/darwin/system.nix
+++ b/modules/darwin/system.nix
@@ -8,6 +8,12 @@ _: {
       hostName = "zakkart";
       computerName = "zakkart";
       # localHostName defaults to hostName already.
+
+      applicationFirewall = {
+        enable = true;
+        allowSigned = true;
+        allowSignedApp = true;
+      };
     };
 
     time.timeZone = "America/Port_of_Spain";

--- a/modules/hosts/zakkart/default.nix
+++ b/modules/hosts/zakkart/default.nix
@@ -19,6 +19,7 @@
         self.darwinModules.homebrew
         self.darwinModules.apps
         self.darwinModules.system
+        self.darwinModules.preferences
       ];
 
       nixpkgs.hostPlatform = "aarch64-darwin";

--- a/modules/packages/fish.nix
+++ b/modules/packages/fish.nix
@@ -31,6 +31,14 @@
           # resolve. NixOS needs none of this: login PATH already carries the
           # system profile there.
           fish_add_path --global --move --path $HOME/.nix-profile/bin /etc/profiles/per-user/$USER/bin /run/current-system/sw/bin /nix/var/nix/profiles/default/bin
+
+          # nix-darwin's programs.direnv exports DIRENV_CONFIG=/etc/direnv via
+          # environment.variables, but that only reaches shells that source
+          # nix-darwin's set-environment, which this wrapped fish (deliberately
+          # not programs.fish) never does. Without it direnv never loads
+          # /etc/direnv/direnvrc -- the nix-direnv loader -- and silently falls
+          # back to its builtin uncached use_flake. NixOS hosts are unaffected.
+          set -gx DIRENV_CONFIG /etc/direnv
         ''}
         status is-interactive; and begin
           source ${donefish}


### PR DESCRIPTION
## Summary

- **Fix**: fish login shells on zakkart never received `DIRENV_CONFIG=/etc/direnv` (the wrapped fish deliberately isn't nix-darwin's `programs.fish`, so it never sources `set-environment`). direnv therefore never loaded the nix-direnv loader, `nix_direnv_manual_reload` was undefined, and `use flake` fell back to direnv's builtin uncached implementation — re-evaluating the dev shell every prompt. The wrapper now exports the variable itself, next to the existing PATH fixup.
- **Feature**: declare zakkart's desktop preferences (new `modules/darwin/preferences.nix`, ADR 0010):
  - dock on the right with autohide; hot corners (BL App Windows, BR Mission Control, TR Notification Center)
  - menu bar mirroring the observed macOS 26 values (clock weekday-only, no battery %, Bluetooth/Weather shown, Spotlight icon hidden) — scripted `-currentHost` writes where nix-darwin's options write stale pre-macOS-26 constants
  - pink accent + highlight via `CustomUserPreferences`
  - application firewall (enabled, signed software allowed)
  - Spotlight ⌘Space hotkey disabled via merge-safe `-dict-add` (Raycast owns ⌘Space)
  - wallpaper from `assets/wallpaper.jpg`, Helium as default browser (`defaultbrowser` from nixpkgs), built-in display at "More Space" via `displayplacer` (pinned homebrew-core formula — no new tap)
  - user-context steps follow ADR 0010's failure policy: deterministic defaults writes fail loudly, TCC/LaunchServices/WindowServer steps warn and continue (incl. headless activations where `displayplacer list` can't reach WindowServer)
- Deliberately out of scope: Night Shift (private CoreBrightness format, documented in ADR 0010) and Google Internet Accounts (not declaratively possible).

## Validation

- `just fmt` clean (alejandra/deadnix/statix)
- `nix build .#checks.aarch64-darwin.zakkart-system` (the CI darwin check) built natively on zakkart
- Emitted `result/activate` inspected: firewall flags, controlcenter writes, hotkey dict-add, wallpaper store path, defaultbrowser guard, and displayplacer guard all present with correct shell escaping

## Post-merge

First `just darwin-switch` will show two one-time dialogs (System Events automation consent for the wallpaper; default-browser confirmation). A second switch should run quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)