### PR TITLE
feat(darwin): hide dock recents and set title bar double-click to fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Zakkart: a nix-darwin host for the macOS workstation (`modules/hosts/zakkart/`, `modules/darwin/`), managed with Determinate Nix (ADR 0008) and nixpkgs-first application sourcing with Homebrew/App Store exceptions (ADR 0009). Includes a `just darwin-switch` recipe, a `checks.aarch64-darwin.zakkart-system` CI check built on a hosted macOS runner, and `docs/runbooks/zakkart-bootstrap.md`.
 - Zakkart macOS preferences (`modules/darwin/preferences.nix`): dock moved right with autohide and hot corners, menu bar mirroring the observed macOS 26 values, pink accent/highlight colors, the application firewall, the repo's `assets/wallpaper.jpg`, Helium as the default browser via `defaultbrowser`, the built-in display scaled to "More Space" via `displayplacer`, and the Spotlight (Cmd+Space) hotkey disabled — per `docs/adr/0010-script-user-scoped-macos-preferences-nix-darwin-cannot-express.md`.
+- Zakkart: hide recent/suggested apps in the dock (`dock.show-recents = false`) and set the window title bar double-click action to Fill (`AppleActionOnDoubleClick`, no nix-darwin option on the pinned rev).
 
 ### Fixed
 

--- a/modules/darwin/preferences.nix
+++ b/modules/darwin/preferences.nix
@@ -24,6 +24,7 @@ _: {
           wvous-bl-corner = 3;
           wvous-br-corner = 2;
           wvous-tr-corner = 12;
+          show-recents = false;
         };
 
         menuExtraClock = {
@@ -37,6 +38,9 @@ _: {
         CustomUserPreferences.NSGlobalDomain = {
           AppleAccentColor = 6;
           AppleHighlightColor = "1.000000 0.749020 0.823529 Pink";
+          # "Fill" is the macOS 26 window-tiling action; the pinned
+          # nix-darwin has no option for this key.
+          AppleActionOnDoubleClick = "Fill";
         };
       };
 


### PR DESCRIPTION
## Summary

Two small zakkart preference additions on top of #80:

- `system.defaults.dock.show-recents = false` — hide recent/suggested apps in the dock (native nix-darwin option).
- `AppleActionOnDoubleClick = "Fill"` — window title bar double-click fills the screen (macOS 26 tiling action). No nix-darwin option on the pinned rev, so it rides the existing `CustomUserPreferences.NSGlobalDomain` block per ADR 0010.

Based on #80; **retarget to `main` once #80 merges** (GitHub does this automatically if the base branch is deleted on merge).

## Validation

- `just fmt` clean
- `nix build .#checks.aarch64-darwin.zakkart-system` built natively

🤖 Generated with [Claude Code](https://claude.com/claude-code)