### PR TITLE
feat(edge): ship caddy access logs to victorialogs via journald

### DIFF
--- a/modules/hosts/legion/default.nix
+++ b/modules/hosts/legion/default.nix
@@ -221,6 +221,19 @@ in {
           enable = true;
           settings.Upload.URL = "http://${legionNodes.legion-node3.privateIPv4}:9428/insert/journald";
         };
+
+        # Cap the local journal's on-disk footprint. No explicit limit
+        # existed before (systemd's own default is min(10% of the
+        # filesystem, 4G) per journald.conf(5) SystemMaxUse), and the edge
+        # node's Caddy now writes its per-site access logs to stderr (its
+        # named `journald` logger, modules/nixos/edge/default.nix) in
+        # addition to runtime logs, adding real volume to the journal on
+        # legion-node1. Safe to cap tightly fleet-wide (all four Legion
+        # nodes get this, not just the edge) because the local journal is
+        # only a short debugging buffer now -- systemd-journal-upload above
+        # already ships everything to legion-node3's VictoriaLogs, which
+        # retains a month of history.
+        journald.extraConfig = "SystemMaxUse=1G";
       };
 
       # Restic backup jobs derived from this node's own inventory entry;

--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -33,6 +33,18 @@
     # the site block's first real directive.
     crowdsecLine = lib.optionalString cfg.crowdsec.enable "crowdsec\n            ";
     appsecLine = lib.optionalString cfg.crowdsec.enable "appsec\n            ";
+
+    # Bare `log` directive, same concatenation pattern as crowdsecLine/appsecLine
+    # above. Caddy 2's HTTP access logging is opt-in per site block -- with
+    # no `log` directive a site produces zero access records, even though
+    # the named `journald` logger declared in globalConfig below exists and
+    # is reachable. Added unconditionally (not gated on cfg.crowdsec.enable)
+    # to every public site block except the private-network-only metrics
+    # listener (logging Prometheus's 15s scrape interval would just be
+    # noise); each block routes into whichever loggers are configured
+    # globally (`journald` -- and implicitly `default`, since Caddy always
+    # runs the default logger unless a site opts out of it).
+    logLine = "log\n            ";
   in {
     options.edge.crowdsec.enable =
       lib.mkEnableOption ''
@@ -52,20 +64,46 @@
         enable = true;
         package = self.packages.${system}.caddy;
 
-        # Default logger doubles as the access log for every site block
-        # below (Caddy uses a custom logger named "default" for both
-        # purposes). JSON file, not journald: CrowdSec's log acquisition
-        # reads a stable file path instead of mapping journal fields.
+        # Default (unnamed) logger: this is CrowdSec's acquisition source
+        # of truth, not a general access log -- modules/nixos/crowdsec/default.nix
+        # tails this exact file path (`services.caddy.logDir`/access.log)
+        # via a `source = "file"` acquisition, which needs a stable
+        # filesystem path rather than journal fields. It does NOT double
+        # as "the" access log for every site block: Caddy access logging
+        # is opt-in per site block (see the bare `log` line added to each
+        # public site block below), and the named `journald` logger in
+        # globalConfig below is what actually feeds those records (plus
+        # runtime logs) to VictoriaLogs via the fleet's systemd-journal-upload.
+        # Retention here is intentionally short: VictoriaLogs is now the
+        # searchable month-long archive, so this file only needs to cover
+        # CrowdSec's live tail plus a little local debugging headroom, not
+        # long-term storage.
         logFormat = ''
           level INFO
           output file ${config.services.caddy.logDir}/access.log {
             roll_size 100mb
-            roll_keep 10
+            roll_keep 2
+            roll_keep_for 48h
           }
           format json
         '';
 
         globalConfig = ''
+          # Second named logger: everything (runtime + every site's access
+          # log once `log` is added to that site block below) to stderr,
+          # which systemd captures into the journal, which the fleet's
+          # existing systemd-journal-upload ships to legion-node3's
+          # VictoriaLogs (modules/hosts/legion/default.nix
+          # `services.journald.upload`). No `include`/`exclude` filter on
+          # this logger -- deliberate, so both runtime and access records
+          # land in VictoriaLogs unfiltered; the file logger above stays
+          # the narrower CrowdSec-only source.
+          log journald {
+            output stderr
+            format json
+            level INFO
+          }
+
           # The top-level `metrics` global option turns on Prometheus
           # metrics collection for every HTTP
           # server config below (the older `servers { metrics }` nested
@@ -145,7 +183,7 @@
           # requesting a second certificate per hostname (see
           # https://caddyserver.com/docs/automatic-https#wildcard-certificates).
           jeiang.dev, *.jeiang.dev {
-            ${crowdsecLine}${appsecLine}tls {
+            ${logLine}${crowdsecLine}${appsecLine}tls {
               dns hetzner {env.HETZNER_DNS_TOKEN}
             }
 
@@ -166,7 +204,7 @@
           # (Hetzner-hosted zones, not part of the jeiang.dev wildcard
           # SAN).
           aidanpinard.co {
-            ${crowdsecLine}${appsecLine}tls {
+            ${logLine}${crowdsecLine}${appsecLine}tls {
               dns hetzner {env.HETZNER_DNS_TOKEN}
             }
             root * ${website}
@@ -174,7 +212,7 @@
           }
 
           pinard.co.tt {
-            ${crowdsecLine}${appsecLine}tls {
+            ${logLine}${crowdsecLine}${appsecLine}tls {
               dns hetzner {env.HETZNER_DNS_TOKEN}
             }
             root * ${website}
@@ -186,14 +224,14 @@
           # directive, so this falls back to Caddy's standard automatic
           # HTTPS (HTTP-01/TLS-ALPN-01), per the TLS strategy section.
           noelejoshua.com {
-            ${crowdsecLine}${appsecLine}root * ${portfolio}
+            ${logLine}${crowdsecLine}${appsecLine}root * ${portfolio}
             file_server
           }
 
           # --- auth.jeiang.dev: Pocket ID ---------------------------------
           # Port 1411 is Pocket ID's default listen port.
           auth.jeiang.dev {
-            ${crowdsecLine}${appsecLine}reverse_proxy ${node2}:1411
+            ${logLine}${crowdsecLine}${appsecLine}reverse_proxy ${node2}:1411
           }
 
           # --- attic.jeiang.dev: Attic ------------------------------------
@@ -210,7 +248,7 @@
           # single-node edge, avoiding both the false-positive risk and
           # the cost of body inspection on large NAR blobs.
           attic.jeiang.dev {
-            ${crowdsecLine}reverse_proxy ${node4}:8080 {
+            ${logLine}${crowdsecLine}reverse_proxy ${node4}:8080 {
               transport http {
                 read_timeout 15m
                 write_timeout 15m
@@ -223,13 +261,13 @@
           # Port 5006 matches Actual Budget's configured listen port
           # (modules/nixos/actual-budget.nix).
           budget.jeiang.dev {
-            ${crowdsecLine}${appsecLine}reverse_proxy ${node4}:5006
+            ${logLine}${crowdsecLine}${appsecLine}reverse_proxy ${node4}:5006
           }
 
           # --- grafana.jeiang.dev: monitoring stack -----------------------
           # Port 3000 is Grafana's default listen port.
           grafana.jeiang.dev {
-            ${crowdsecLine}${appsecLine}reverse_proxy ${node3}:3000
+            ${logLine}${crowdsecLine}${appsecLine}reverse_proxy ${node3}:3000
           }
 
           # --- netbird.jeiang.dev: NetBird server/relay -------------------
@@ -249,7 +287,7 @@
             # allow-rule for these same paths as a second layer -- skipping
             # the handler here avoids paying for AppSec inspection on
             # streaming traffic it would just allow anyway.
-            ${crowdsecLine}@grpc path /signalexchange.SignalExchange/* /management.ManagementService/* /management.ProxyService/*
+            ${logLine}${crowdsecLine}@grpc path /signalexchange.SignalExchange/* /management.ManagementService/* /management.ProxyService/*
             handle @grpc {
               reverse_proxy h2c://${node2}:80
             }
@@ -301,13 +339,13 @@
           # $out/dist (verified via `nix flake show`/`nix build`), so it's
           # served the same way as the other static sites above.
           bill-split.jeiang.dev {
-            ${crowdsecLine}${appsecLine}root * ${billSplitter}
+            ${logLine}${crowdsecLine}${appsecLine}root * ${billSplitter}
             file_server
           }
 
           # --- github.jeiang.dev: redirect --------------------------------
           github.jeiang.dev {
-            ${crowdsecLine}${appsecLine}redir https://github.com/jeiang{uri} 301
+            ${logLine}${crowdsecLine}${appsecLine}redir https://github.com/jeiang{uri} 301
           }
 
           # --- jellyfin.plyrex.dev / seerr.plyrex.dev: placeholders -------
@@ -317,7 +355,7 @@
           # cache. Not in Hetzner DNS, so (like noelejoshua.com) these fall
           # back to standard automatic HTTPS.
           jellyfin.plyrex.dev, seerr.plyrex.dev {
-            ${crowdsecLine}${appsecLine}respond "Service migrating. This service is temporarily unavailable while it moves to new infrastructure." 503
+            ${logLine}${crowdsecLine}${appsecLine}respond "Service migrating. This service is temporarily unavailable while it moves to new infrastructure." 503
           }
         '';
       };

--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -52,8 +52,9 @@
     # never reach disk or the journal in the first place (filtering at
     # the encoder beats filtering downstream -- VictoriaLogs and the
     # rolled files would otherwise retain them). Request Authorization/
-    # Proxy-Authorization carry credentials; the response Location
-    # header is dropped because redirect targets routinely embed OAuth
+    # Proxy-Authorization/Cookie and response Set-Cookie carry
+    # credentials and session tokens; the response Location header is
+    # dropped because redirect targets routinely embed OAuth
     # authorization codes and signed tokens (e.g. the Pocket ID flows
     # behind auth.jeiang.dev).
     logEncoder = ''
@@ -62,6 +63,8 @@
         fields {
           request>headers>Authorization delete
           request>headers>Proxy-Authorization delete
+          request>headers>Cookie delete
+          resp_headers>Set-Cookie delete
           resp_headers>Location delete
         }
       }

--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -45,6 +45,27 @@
     # globally (`journald` -- and implicitly `default`, since Caddy always
     # runs the default logger unless a site opts out of it).
     logLine = "log\n            ";
+
+    # Shared encoder for BOTH global loggers (default file logger via
+    # `logFormat`, named `journald` logger in globalConfig): plain JSON
+    # wrapped in Caddy's `filter` encoder so sensitive header values
+    # never reach disk or the journal in the first place (filtering at
+    # the encoder beats filtering downstream -- VictoriaLogs and the
+    # rolled files would otherwise retain them). Request Authorization/
+    # Proxy-Authorization carry credentials; the response Location
+    # header is dropped because redirect targets routinely embed OAuth
+    # authorization codes and signed tokens (e.g. the Pocket ID flows
+    # behind auth.jeiang.dev).
+    logEncoder = ''
+      format filter {
+        wrap json
+        fields {
+          request>headers>Authorization delete
+          request>headers>Proxy-Authorization delete
+          resp_headers>Location delete
+        }
+      }
+    '';
   in {
     options.edge.crowdsec.enable =
       lib.mkEnableOption ''
@@ -85,7 +106,7 @@
             roll_keep 2
             roll_keep_for 48h
           }
-          format json
+          ${logEncoder}
         '';
 
         globalConfig = ''
@@ -100,7 +121,7 @@
           # the narrower CrowdSec-only source.
           log journald {
             output stderr
-            format json
+            ${logEncoder}
             level INFO
           }
 

--- a/modules/nixos/monitoring/caddy.json
+++ b/modules/nixos/monitoring/caddy.json
@@ -774,6 +774,212 @@
           ]
         }
       ]
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Access Logs",
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "panels": [
+        {
+          "id": 201,
+          "type": "timeseries",
+          "title": "Requests over time by status class",
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victorialogs"
+          },
+          "description": "Access-log request counts bucketed by HTTP status class (2xx/3xx/4xx/5xx), sourced from Caddy's per-site `log` output rather than caddy.json's Prometheus metrics (modules/nixos/edge/default.nix enables per-site access logging; Requests by status code above already covers the metrics view). Prefiltered on the literal `\"handled request\"` access-log message before unpack_json so the JSON decode only runs on access records, not runtime log lines; unpack_json then flattens the record so `status` is a plain numeric field, and `math floor(status / 100) as class` buckets it into 2/3/4/5. `floor()` confirmed supported by the pinned victorialogs package (nixpkgs services.victorialogs.package, 1.52.0 here; the function shipped in victorialogs v0.17.0). Uses the plugin's 'Range' query type (/select/logsql/stats_query_range), the same queryType logs.json's Log volume panel uses.",
+          "gridPos": {
+            "x": 0,
+            "y": 37,
+            "w": 12,
+            "h": 8
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "lineWidth": 1,
+                "fillOpacity": 60,
+                "gradientMode": "none",
+                "spanNulls": false,
+                "showPoints": "never",
+                "pointSize": 5,
+                "stacking": {
+                  "mode": "normal",
+                  "group": "A"
+                },
+                "axisPlacement": "auto",
+                "axisLabel": "",
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "hideFrom": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "showLegend": true,
+              "displayMode": "list",
+              "placement": "bottom",
+              "calcs": []
+            }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "victoriametrics-logs-datasource",
+                "uid": "victorialogs"
+              },
+              "expr": "_SYSTEMD_UNIT:=\"caddy.service\" \"handled request\" | unpack_json | math floor(status / 100) as class | stats by (class) count() requests",
+              "queryType": "statsRange",
+              "legendFormat": "{{class}}xx"
+            }
+          ]
+        },
+        {
+          "id": 202,
+          "type": "table",
+          "title": "Top hosts",
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victorialogs"
+          },
+          "description": "Busiest Host headers over the dashboard's time range, from Caddy's access log. Same `\"handled request\"` prefilter + unpack_json as the panel above; `request.host` is the dot-flattened name unpack_json gives the nested access-log `request.host` field (verified against Caddy's JSON access-log schema, caddyhttp/accesslog.go -- the `request` object it logs carries a `host` field). Uses the plugin's 'Raw Logs' query type (/select/logsql/query, queryType instant), same as logs.json's Log stream panel -- a `stats`-aggregated result is just a handful of rows, no range-series endpoint needed.",
+          "gridPos": {
+            "x": 12,
+            "y": 37,
+            "w": 12,
+            "h": 8
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false,
+              "reducer": ["sum"],
+              "countRows": false,
+              "fields": ""
+            },
+            "sortBy": [
+              {
+                "displayName": "requests",
+                "desc": true
+              }
+            ]
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "victoriametrics-logs-datasource",
+                "uid": "victorialogs"
+              },
+              "expr": "_SYSTEMD_UNIT:=\"caddy.service\" \"handled request\" | unpack_json | stats by (request.host) count() requests | sort by (requests) desc | limit 10",
+              "queryType": "instant"
+            }
+          ]
+        },
+        {
+          "id": 203,
+          "type": "logs",
+          "title": "Access log stream",
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victorialogs"
+          },
+          "description": "Raw Caddy access-log records (msg \"handled request\"), newest first, JSON-unpacked so per-request fields (request.host, request.uri, request.remote_ip, status, duration, ...) are inspectable per line. Same underlying log source as the 'Caddy logs' runtime panel above (_SYSTEMD_UNIT:=\"caddy.service\"), filtered down to only access records via the same prefilter used by the other two panels in this row. 'Raw Logs' query type (/select/logsql/query), mirroring logs.json's Log stream panel.",
+          "gridPos": {
+            "x": 0,
+            "y": 45,
+            "w": 24,
+            "h": 12
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "showTime": true,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "victoriametrics-logs-datasource",
+                "uid": "victorialogs"
+              },
+              "expr": "_SYSTEMD_UNIT:=\"caddy.service\" \"handled request\" | unpack_json",
+              "queryType": "instant",
+              "direction": "desc",
+              "maxLines": 500
+            }
+          ]
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary
- Enable per-site HTTP access logging on the edge — Caddy 2 makes it opt-in per site block, and no block had a `log` directive, so `/var/log/caddy/access.log` held only runtime logs and CrowdSec's caddy parser (incl. the `target_fqdn` attic whitelist) has been starved of request data this whole time. The module comment claiming the default logger "doubles as the access log" was wrong and is rewritten.
- Add a named `journald` global logger (stderr, JSON) so everything flows through the fleet's existing systemd-journal-upload into VictoriaLogs on legion-node3 — no shipper agents, no firewall changes. Fields are decoded at query time with LogsQL `| unpack_json` (e.g. `request.host`, `status`, `duration`).
- Keep logs from ballooning now that access records are real: file rolling tightened to `roll_keep 2` + `roll_keep_for 48h` (~100MB live + 2 gzipped rolls, was ~1GB ceiling), and a fleet-wide journald `SystemMaxUse=1G` cap. VictoriaLogs' 1-month retention is the searchable archive.
- New collapsed **Access Logs** row in the Caddy dashboard: requests-over-time by status class (`math floor(status/100)` — supported since VL 0.17.0, nixpkgs pins 1.52.0), top-hosts table, unpacked access-log stream. Existing runtime-logs panel untouched.

## Validation
- Pure `nix eval` of legion-node1 and legion-node3 toplevel drvPaths (full linux builds not possible on this darwin host; deploys use `--remote-build`).
- Rendered the actual Caddyfile from the module and ran the repo's own Caddy 2.11.4 `caddy validate` against it → **Valid configuration**.
- Dashboard JSON validated with jq.

## Test plan
- [ ] Deploy legion-node1, hit a public site, confirm `journalctl -u caddy.service` shows JSON access records
- [ ] Deploy legion-node3, confirm the three new dashboard panels render
- [ ] `curl http://127.0.0.1:9428/select/logsql/query -d 'query=_SYSTEMD_UNIT:="caddy.service" "handled request" | unpack_json | request.host:"jeiang.dev"'` on node3 returns decoded records
- [ ] `cscli metrics` shows the caddy parser consuming lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)