### PR TITLE
feat: add obsidian to artemis and zakkart

### DIFF
--- a/modules/darwin/apps.nix
+++ b/modules/darwin/apps.nix
@@ -17,6 +17,7 @@
         discord
         iina
         mos
+        obsidian
         qbittorrent
         raycast
         telegram-desktop

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -115,6 +115,7 @@
           ".config/Bitwarden"
           ".config/discord"
           ".config/heroic"
+          ".config/obsidian"
           ".config/PrismLauncher"
           ".config/qBittorrent"
           ".config/easyeffects"

--- a/modules/nixos/desktop.nix
+++ b/modules/nixos/desktop.nix
@@ -30,6 +30,7 @@
         # needed for dolphin's file associations
         kdePackages.kservice
         mpv
+        obsidian
         pwvucontrol
         qbittorrent
         qview


### PR DESCRIPTION
Adds `obsidian` from nixpkgs to both hosts:

- **artemis**: system package in the desktop module, plus `.config/obsidian` persisted so the vault registry and app state survive the impermanence root rollback
- **zakkart**: nixpkgs-first GUI list in the darwin apps module (docs/adr/0009)

Both toplevels pure-eval clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)