### PR TITLE
feat(nix): adopt determinate nix on the nixos fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Zakkart: a nix-darwin host for the macOS workstation (`modules/hosts/zakkart/`, `modules/darwin/`), managed with Determinate Nix (ADR 0008) and nixpkgs-first application sourcing with Homebrew/App Store exceptions (ADR 0009). Includes a `just darwin-switch` recipe, a `checks.aarch64-darwin.zakkart-system` CI check built on a hosted macOS runner, and `docs/runbooks/zakkart-bootstrap.md`.
 - Zakkart macOS preferences (`modules/darwin/preferences.nix`): dock moved right with autohide and hot corners, menu bar mirroring the observed macOS 26 values, pink accent/highlight colors, the application firewall, the repo's `assets/wallpaper.jpg`, Helium as the default browser via `defaultbrowser`, the built-in display scaled to "More Space" via `displayplacer`, and the Spotlight (Cmd+Space) hotkey disabled — per `docs/adr/0010-script-user-scoped-macos-preferences-nix-darwin-cannot-express.md`.
 - Zakkart: hide recent/suggested apps in the dock (`dock.show-recents = false`) and set the window title bar double-click action to Fill (`AppleActionOnDoubleClick`, no nix-darwin option on the pinned rev).
+- Adopt Determinate Nix on the NixOS fleet (legion-node1..4, artemis) by importing Determinate's NixOS module in `modules/nixos/nix.nix` -- per ADR 0011, this keeps the existing `nix.settings` working unchanged (rendered to `/etc/nix/nix.custom.conf`).
 
 ### Fixed
 

--- a/docs/adr/0011-adopt-determinate-nix-on-the-nixos-fleet.md
+++ b/docs/adr/0011-adopt-determinate-nix-on-the-nixos-fleet.md
@@ -1,0 +1,28 @@
+# Adopt Determinate Nix on the NixOS fleet
+
+Zakkart (the macOS workstation) moved to Determinate Nix in docs/adr/0008,
+which called out the config drift between its Determinate-specific
+expression and the NixOS hosts' `nix.*` settings, and named finishing the
+move onto the NixOS fleet as the closing move. This ADR closes that gap: all
+NixOS hosts (legion-node1..4, artemis) now import Determinate's NixOS
+module.
+
+Unlike the darwin module, the Determinate NixOS module keeps the stock
+NixOS `nix.*` options fully active — it retargets the generated nix.conf to
+`/etc/nix/nix.custom.conf`, sets `nix.package` to Determinate Nix, and
+rewires `nix-daemon.service`'s `ExecStart` to `determinate-nixd`. It does
+not rewrite settings into a separate Determinate-only mechanism the way the
+darwin module does. So `modules/nixos/nix.nix`'s existing `nix.settings`
+(substituters, trusted keys, registry pinning, etc.) carries over unchanged;
+no parallel Determinate-compatible expression is needed on NixOS.
+
+## Consequences
+
+- Nix's version on the fleet now comes from the `determinate` flake input
+  rather than nixpkgs, so `flake.lock` bumps to that input are how Nix
+  itself is upgraded going forward.
+- `determinate-nixd` owns `/etc/nix/nix.conf` and the `nix-daemon.service`
+  `ExecStart`, in place of stock nixpkgs Nix.
+- The bare `substituters` list in `modules/nixos/nix.nix` still overrides
+  Determinate's default substituters, same as before this change (attic,
+  helix, hyprland caches only) — behavior is unchanged.

--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,12 @@
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-darwin.url = "github:nix-darwin/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
-    # Determinate manages the Nix installation itself on Zakkart (see
-    # docs/adr/0008); its own installer owns the daemon/upgrades, so this
-    # flake only needs its nix-darwin module, not a separate Nix. Following
-    # our nixpkgs here would be pointless anyway: `determinate-nixd` is a
-    # prebuilt binary the module fetches, not something this flake builds.
+    # Determinate manages the Nix installation on Zakkart via its
+    # nix-darwin module (docs/adr/0008), whose installer owns the
+    # daemon/upgrades, and on the NixOS fleet via its NixOS module
+    # (docs/adr/0011). Following our nixpkgs here would be pointless anyway:
+    # `determinate-nixd` is a prebuilt binary the module fetches, not
+    # something this flake builds.
     determinate.url = "github:DeterminateSystems/determinate";
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
     # Homebrew itself and its taps: pinned as flake inputs so

--- a/modules/nixos/nix.nix
+++ b/modules/nixos/nix.nix
@@ -20,6 +20,10 @@
   }: {
     imports = [
       inputs.nix-index-database.nixosModules.nix-index
+      # Determinate keeps the stock NixOS nix.* module active (see
+      # docs/adr/0011); it just retargets rendered settings to
+      # /etc/nix/nix.custom.conf, so the settings below carry over unchanged.
+      inputs.determinate.nixosModules.default
     ];
 
     nixpkgs.pkgs = withSystem config.nixpkgs.hostPlatform.system ({pkgs, ...}: pkgs);


### PR DESCRIPTION
## Summary

Swaps all five NixOS hosts (legion-node1..4, artemis) to Determinate Nix by importing `inputs.determinate.nixosModules.default` in the shared nix module, closing the config-drift gap ADR 0008 accepted when zakkart moved first.

- Unlike the darwin module, Determinate's NixOS module keeps the stock `nix.*` machinery active — the generated nix.conf just retargets to `/etc/nix/nix.custom.conf`, `nix.package` becomes Determinate Nix, and `nix-daemon` runs `determinate-nixd`. Existing `nix.settings` (bare substituters, legion's `trusted-users = ["deploy"]` merge) carry over unchanged.
- No flake.lock change: the locked `determinate` input already carries the Linux `determinate-nixd` binaries.
- Docs: new ADR 0011, updated `determinate` input comment, CHANGELOG line.

## Verification

- Pure eval of every host toplevel (artemis + legion-node1..4) succeeds; zakkart unchanged.
- `nix.package.pname` → `determinate-nix`; `environment.etc."nix/nix.conf".target` → `nix/nix.custom.conf`.
- statix clean; pre-commit hooks pass.

## Rollout

Deploy one legion node first (`just deploy node1 -s --remote-build`), confirm `nix --version` reports Determinate and `systemctl cat nix-daemon` shows the determinate-nixd ExecStart, then `just deploy-legion` and rebuild artemis locally. deploy-rs magic rollback covers a bad activation on legion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)