### PR TITLE
feat(edge,netbird-proxy): switch ACME DNS-01 from Hetzner to Cloudflare

### DIFF
--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -208,7 +208,7 @@
           # https://caddyserver.com/docs/automatic-https#wildcard-certificates).
           jeiang.dev, *.jeiang.dev {
             ${logLine}${crowdsecLine}${appsecLine}tls {
-              dns hetzner {env.HETZNER_DNS_TOKEN}
+              dns cloudflare {env.CLOUDFLARE_API_TOKEN}
             }
 
             @apex host jeiang.dev
@@ -225,11 +225,11 @@
           }
 
           # aidanpinard.co / pinard.co.tt: separate DNS-01 certs
-          # (Hetzner-hosted zones, not part of the jeiang.dev wildcard
+          # (Cloudflare-hosted zones, not part of the jeiang.dev wildcard
           # SAN).
           aidanpinard.co {
             ${logLine}${crowdsecLine}${appsecLine}tls {
-              dns hetzner {env.HETZNER_DNS_TOKEN}
+              dns cloudflare {env.CLOUDFLARE_API_TOKEN}
             }
             root * ${website}
             file_server
@@ -237,14 +237,14 @@
 
           pinard.co.tt {
             ${logLine}${crowdsecLine}${appsecLine}tls {
-              dns hetzner {env.HETZNER_DNS_TOKEN}
+              dns cloudflare {env.CLOUDFLARE_API_TOKEN}
             }
             root * ${website}
             file_server
           }
 
           # --- noelejoshua.com: jkmn-website, new input -------------------
-          # noelejoshua.com is not in Hetzner DNS: no explicit `tls`
+          # noelejoshua.com is not in Cloudflare DNS: no explicit `tls`
           # directive, so this falls back to Caddy's standard automatic
           # HTTPS (HTTP-01/TLS-ALPN-01), per the TLS strategy section.
           noelejoshua.com {
@@ -376,7 +376,7 @@
           # jellyfin/seerr have a deferred Tailscale backend. 503 rather
           # than 200: accurately signals "temporarily unavailable" instead
           # of looking like real content that a client or proxy might
-          # cache. Not in Hetzner DNS, so (like noelejoshua.com) these fall
+          # cache. Not in Cloudflare DNS, so (like noelejoshua.com) these fall
           # back to standard automatic HTTPS.
           jellyfin.plyrex.dev, seerr.plyrex.dev {
             ${logLine}${crowdsecLine}${appsecLine}respond "Service migrating. This service is temporarily unavailable while it moves to new infrastructure." 503
@@ -384,13 +384,13 @@
         '';
       };
 
-      # Hetzner DNS API token for the DNS-01 issuer above, from the caddy
+      # Cloudflare DNS API token for the DNS-01 issuer above, from the caddy
       # secrets shard.
       sops.secrets = let
         sopsFile = ./secrets.yaml;
       in
         {
-          "caddy/hetzner-dns-token" = {inherit sopsFile;};
+          "caddy/cloudflare-dns-token" = {inherit sopsFile;};
         }
         // lib.optionalAttrs cfg.crowdsec.enable {
           "caddy/crowdsec-lapi-url" = {inherit sopsFile;};
@@ -401,7 +401,7 @@
         owner = config.services.caddy.user;
         group = config.services.caddy.group;
         content =
-          "HETZNER_DNS_TOKEN=${config.sops.placeholder."caddy/hetzner-dns-token"}\n"
+          "CLOUDFLARE_API_TOKEN=${config.sops.placeholder."caddy/cloudflare-dns-token"}\n"
           + lib.optionalString cfg.crowdsec.enable ''
             CROWDSEC_LAPI_URL=${config.sops.placeholder."caddy/crowdsec-lapi-url"}
             CROWDSEC_LAPI_KEY=${config.sops.placeholder."caddy/crowdsec-lapi-key"}

--- a/modules/nixos/edge/secrets.yaml
+++ b/modules/nixos/edge/secrets.yaml
@@ -1,5 +1,6 @@
 caddy:
     hetzner-dns-token: ENC[AES256_GCM,data:OXdaau5KUedYqf5mC67iRWtY0DgdExjSVaeXQWJTtLFQ3O2+Ta65nW3vGUmBcZRxvr4huJAHxXuVV49e5StKAA==,iv:qeRj2eZ3/TKmxgmkOVthbn1Ar/j3GXXhIu8M1bKvioQ=,tag:Q7Sm2udDxOdkXzslpDpBOg==,type:str]
+    cloudflare-dns-token: ENC[AES256_GCM,data:L7j1yS8l1FthPSzWjEE8ydMuKHjRRpAJCIsd4p34ea/lcgbwG7MSuMWZmEBRZdCiY/K569g=,iv:7A7jSfkkvguN8LmlnJxxwZQ8CPOxtUBohCoTWOY96Rw=,tag:6M56rBnHZH2bZSbXxABYsQ==,type:str]
     crowdsec-lapi-url: ENC[AES256_GCM,data:yQoxecKcMwl0dW5Ry9w+kgvJUUbX+Q==,iv:4/yqbGcDQ8fOIcmKqEonP+onlRQicizmEC98jiRDv28=,tag:J6xMF61nxsMb7rhmjZISaQ==,type:str]
     crowdsec-lapi-key: ENC[AES256_GCM,data:4741LwzuDG5gigPkw38DfAWHbG1YKnB212zqZPhSYkzsCX1LYbuGd6ukrN2jagxQxj6SdO5Q6tYnBGucDlRAfg==,iv:fs6kgxTfhH7fB8IdcMWDYDB9iXS/cUit6eLd7o7/aCI=,tag:wiSm1yMoUXt1Em2M/njavA==,type:str]
 sops:
@@ -22,7 +23,7 @@ sops:
             LPIUXgn7nsE4sXMLicjMOwFU1yDDUq3FllkDKOJRuj8dsJxuYueiGA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fexn9r8huh294w3hmyst605fndjagyg7e3s23aqfedlqrqnn24rq5lvgr7
-    lastmodified: "2026-07-31T21:23:17Z"
-    mac: ENC[AES256_GCM,data:I1/aJEe5NzuoJL4qcKSGIQMCh9pZntJbdhpccHpeZGPxSXP9obX4g8SYhzc4esFj9kTunFo1XStphwZAvdytOVgyU8kFZkrq9Bf9WALxHLZFqd7ISjIJRqEZ1ty0NQVjkrBX471Mf0MV4rX5kDJrdFkMzuEbqSkO45pOln1DzNM=,iv:lKXjq1WtrbzyAFcebKynM6cTUPQ/tYJuUqJczd7KT/0=,tag:rGZp1xUfRSwyrP716hipCg==,type:str]
+    lastmodified: "2026-08-05T05:13:05Z"
+    mac: ENC[AES256_GCM,data:qpKpJYxlQwXnyXpart7av6Z9WNhhNTfc6ZyydW9Y7cbjXQrHpeov/gA+Hwjk/pbggHkJqfTOnus7K/KoJQQSgwZ6OnXWvEZ48mw0quQkCEVa1B0d/RWZh5BdB3fcykasNdFEE+2jRuf6oq2PVSG/Rh7mVlvzx+xYrI7EReItI+E=,iv:qQcIQ4QERAB3Nk6fAoTVcPj+V4+N62/0maFYktw8ZNw=,tag:VOnKXnISgMp5C32Xp/HHdQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3

--- a/modules/nixos/netbird-server/proxy.nix
+++ b/modules/nixos/netbird-server/proxy.nix
@@ -46,7 +46,7 @@
     # (github.com/netbirdio/netbird proxy/server.go `configureTLS`,
     # proxy/cmd/proxy/cmd/root.go flag wiring). So the proxy does NOT need
     # its own ACME at all: `security.acme` below provisions a DNS-01
-    # wildcard for proxy.jeiang.dev/*.proxy.jeiang.dev via the Hetzner
+    # wildcard for proxy.jeiang.dev/*.proxy.jeiang.dev via the Cloudflare
     # provider (same mechanism as the edge's *.jeiang.dev cert,
     # modules/nixos/edge/default.nix) and hands the rendered
     # fullchain.pem/key.pem straight to the proxy; the built-in ACME
@@ -59,15 +59,15 @@
   in {
     security.acme = {
       acceptTerms = true;
-      # Same operator identity that owns the other Hetzner-DNS domains this
+      # Same operator identity that owns the other Cloudflare-DNS domains this
       # flake issues certs for (aidanpinard.co, via Caddy's ACME on the
       # edge); Let's Encrypt requires a contact address for the account.
       defaults.email = "aidan@aidanpinard.co";
 
       certs.${certName} = {
         extraDomainNames = ["*.${domain}"];
-        dnsProvider = "hetzner";
-        environmentFile = config.sops.templates."netbird-proxy-hetzner-dns.env".path;
+        dnsProvider = "cloudflare";
+        environmentFile = config.sops.templates."netbird-proxy-cloudflare-dns.env".path;
         # /var/lib/acme/${certName} readable by this group (chmod
         # u=rwX,g=rX,o= in the nixos acme module); netbird-proxy's service
         # user is added to it below instead of the module default "acme".
@@ -97,11 +97,11 @@
         # value. Stored in the crowdsec shard (that module's shard), not
         # the netbird-proxy shard -- this module reads from both.
         "crowdsec/bouncer-netbird-proxy-key" = {sopsFile = crowdsecSopsFile;};
-        # Same Hetzner DNS API token value as the edge's
-        # `caddy/hetzner-dns-token` (modules/nixos/edge/default.nix),
+        # Same Cloudflare DNS API token value as the edge's
+        # `caddy/cloudflare-dns-token` (modules/nixos/edge/default.nix),
         # stored under its own name since sops secrets are declared (and
         # keyed to recipients) per host.
-        "netbird-proxy/hetzner-dns-token" = {sopsFile = netbirdProxySopsFile;};
+        "netbird-proxy/cloudflare-dns-token" = {sopsFile = netbirdProxySopsFile;};
         # OS-level firewall bouncer key (services.crowdsec-firewall-bouncer
         # below), registered at node1's LAPI by
         # modules/nixos/crowdsec/default.nix under the bouncer name
@@ -119,8 +119,8 @@
           '';
         };
 
-        "netbird-proxy-hetzner-dns.env".content = ''
-          HETZNER_API_TOKEN=${config.sops.placeholder."netbird-proxy/hetzner-dns-token"}
+        "netbird-proxy-cloudflare-dns.env".content = ''
+          CF_DNS_API_TOKEN=${config.sops.placeholder."netbird-proxy/cloudflare-dns-token"}
         '';
       };
     };

--- a/modules/nixos/netbird-server/secrets.proxy.yaml
+++ b/modules/nixos/netbird-server/secrets.proxy.yaml
@@ -2,6 +2,7 @@ netbird:
     proxy-token: ENC[AES256_GCM,data:LSJDXw0D3QKmy70/ZwXP9AVsbxQaly1iTTU4BgwFz8LgfF2nuswD0g==,iv:QYOj0YxeLBEGx9tELkold4Bykv5O6SiygWecPtNdL/M=,tag:M0YPnMmr+rKlOteM5ldfng==,type:str]
 netbird-proxy:
     hetzner-dns-token: ENC[AES256_GCM,data:n9S2ZXIbrhKhtO/fuizrgUsjzE5rl4VKTJ+5u4UgUARBH4IAzO0dUuWFE9/0bDoYSYwB0uTLmpHpqnlWE8JotA==,iv:++G9ZEHxmKDzw8iLJ1pTum+uzed04xNCmpVd7GdsTv4=,tag:152uWGTMGleKvMux1biiOg==,type:str]
+    cloudflare-dns-token: ENC[AES256_GCM,data:n/QUw+enBqdMbTPPJrCnF46w47H5tesp9qX/5CF5wz9OBrGznuv+323P20EWXZrTA66nkGk=,iv:cYUw9SVwuRhfbVU3GiQPjbmRpxODUIgV0falh1INkQI=,tag:KowHLEi3L41Vlxgw5t8U3A==,type:str]
 sops:
     age:
         - enc: |
@@ -22,7 +23,7 @@ sops:
             Ru9vcNwew0n56Ql9bRPVtVvFHz2hTSjfAIbidIiI2+X78TUupvF30w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1f9t7ktuy3hny3lju3692mqx35mrc0wrfrl8mtelyeecc4lydcu0snxtm23
-    lastmodified: "2026-07-31T21:23:17Z"
-    mac: ENC[AES256_GCM,data:Ie9k1A2xVJWaE74h1UirZFSro7vvpGyb7yjw7BttpiGSQhVOL0zMREZvsloiq2gRNcHVTamRpTbGv3HOsnRxRjaLQu4zMJkBChmCbrb0lzwGe01jO1V3xPrM0u/um5jcq6rh43HtyW/qIB5OVKKxlqqwBV9hTXHqFsXOeDt5ydQ=,iv:Xsr3XWguhORE95p6GuJBzUPgIO0kFSWR6MOYrSZRjZg=,tag:QseEvUTk/OgE3q0U01RUiA==,type:str]
+    lastmodified: "2026-08-05T05:13:25Z"
+    mac: ENC[AES256_GCM,data:cO9+HYD4/I8fC6gkJfjZcZEK+giivGukutJHCP8LiR9Jp6HuQx2Pp1WB28JTqa1P3/4Pr6xoOh304tNEhxOBLfKJO9KXaAAet13w2U8oziuZMpWU3BNQMTHykEALLQc/g6IgC1qnjx1bLe1WJJ83qIDWbsDx7aDcqkakcGeLPRE=,iv:ZBIDrPxyo5UyMEE/hHhK/AC4WG2pxJq8fiaiB55Saug=,tag:V97LaVuEzxUqkgcwDwz5eg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3

--- a/modules/packages/caddy.nix
+++ b/modules/packages/caddy.nix
@@ -2,11 +2,11 @@
   perSystem = {pkgs, ...}: {
     packages.caddy = pkgs.caddy.withPlugins {
       plugins = [
-        "github.com/caddy-dns/hetzner@v2.0.1"
+        "github.com/caddy-dns/cloudflare@v0.2.4"
         "github.com/hslatman/caddy-crowdsec-bouncer/http@v0.13.1"
         "github.com/hslatman/caddy-crowdsec-bouncer/appsec@v0.13.1"
       ];
-      hash = "sha256-tc63EA2u5QXluvWHqjBqm+IGtFzzs6WIU4FLyZDwW7A=";
+      hash = "sha256-X1YNG6q0zCxxfix5zTB2keuJXhY38q7lGIgvAPOk3WA=";
       # withPlugins' default installCheckPhase matches plugin specs against
       # `caddy build-info` by full import path, but the CrowdSec bouncer's
       # http/appsec plugins share one go.mod at the repo root, so build-info


### PR DESCRIPTION
## Summary
- Swap the Caddy DNS plugin from `caddy-dns/hetzner` to `caddy-dns/cloudflare@v0.2.4` (new plugin hash; `caddy list-modules` shows `dns.providers.cloudflare`)
- Edge Caddy: the three `dns hetzner` tls blocks (jeiang.dev wildcard, aidanpinard.co, pinard.co.tt) now use `dns cloudflare {env.CLOUDFLARE_API_TOKEN}`
- netbird-proxy lego: `dnsProvider = "cloudflare"`, env `CF_DNS_API_TOKEN`
- sops secrets renamed: `caddy/cloudflare-dns-token` (edge shard), `netbird-proxy/cloudflare-dns-token` (netbird-proxy shard)

## Before deploying
- [ ] Zones delegated to Cloudflare (pinard.co.tt still propagating), all records DNS-only (grey cloud)
- [ ] `just sops-edit modules/nixos/edge/secrets.yaml` → `caddy/cloudflare-dns-token`
- [ ] `just sops-edit modules/nixos/netbird-server/secrets.proxy.yaml` → `netbird-proxy/cloudflare-dns-token`

## Validation
- `nix build .#caddy` passes; plugin modules verified via `caddy list-modules`
- `legion-node1` and `legion-node2` toplevels evaluate

🤖 Generated with [Claude Code](https://claude.com/claude-code)