### PR TITLE
feat(artemis): add qwen/gemma/nemotron models, bump ornith to -np 4 -c 98304

### DIFF
--- a/modules/nixos/llama-swap.nix
+++ b/modules/nixos/llama-swap.nix
@@ -1,6 +1,6 @@
 _: {
-  # Ornith-1.0-9B (Q6_K) served locally on artemis, fronted by llama-swap so
-  # VRAM is freed after idle instead of holding the model resident forever.
+  # Local models served on artemis, fronted by llama-swap so VRAM is freed
+  # after idle instead of holding a model resident forever.
   flake.nixosModules.llama-swap = {
     pkgs,
     lib,
@@ -8,11 +8,23 @@ _: {
   }: let
     llama-cpp = pkgs.llama-cpp.override {vulkanSupport = true;};
     llama-server = lib.getExe' llama-cpp "llama-server";
-    # Ornith-1.0-9B Q6_K, hash-pinned into the store so it survives
-    # reboots (nix store is persisted) with no impermanence entry.
-    model = pkgs.fetchurl {
+    # Models hash-pinned into the store so they survive reboots (nix store
+    # is persisted) with no impermanence entry.
+    ornith = pkgs.fetchurl {
       url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF/resolve/main/ornith-1.0-9b-Q6_K.gguf";
       hash = "sha256-M7b2o+PwUHhDjhLfiktVyKz3jOrcxjnSrxzzWgJug4c=";
+    };
+    qwen = pkgs.fetchurl {
+      url = "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf";
+      hash = "sha256-gJYmV00MtD1L7PpWFpmA2iu0SPIpknD3vkQ8uJ0KauQ=";
+    };
+    gemma = pkgs.fetchurl {
+      url = "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q6_K.gguf";
+      hash = "sha256-bzlDNlALtUCb1owxqp11CXteYQT2zzDIKgmntk30H68=";
+    };
+    nemotron = pkgs.fetchurl {
+      url = "https://huggingface.co/bartowski/nvidia_NVIDIA-Nemotron-Nano-12B-v2-GGUF/resolve/main/nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf";
+      hash = "sha256-ZZZhGQ2fZQrku6JS3jqI7Qu8tg67ToM8xtHbOWEEFtw=";
     };
   in {
     services.llama-swap = {
@@ -29,18 +41,35 @@ _: {
         # Model load (7.4 GB, full GPU offload) can take longer than
         # llama-swap's default health-check timeout.
         healthCheckTimeout = 300;
-        models."ornith-1.0-9b" = {
-          # ${PORT} above is llama-swap's own macro (escaped with the extra
-          # $ so Nix leaves it literal in the generated YAML), not a Nix
-          # interpolation like ${llama-server}/${model} below.
-          # -ngl 99: full GPU offload. -c 40960: still inside the 16 GB VRAM
-          # budget at this quant. --jinja: use the model's embedded chat
-          # template (Ornith is Qwen 3.5-based). --temp/--top-p/--top-k:
-          # sampling defaults per the Ornith-1.0-9B model card.
-          cmd = "${llama-server} --port \${PORT} -m ${model} -ngl 99 -c 40960 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
-          aliases = ["ornith"];
-          # Free all VRAM after 30 min idle.
-          ttl = 1800;
+        # ${PORT} in each cmd is llama-swap's own macro (escaped with the
+        # extra $ so Nix leaves it literal in the generated YAML), not a Nix
+        # interpolation like ${llama-server}/${ornith} etc.
+        # Shared flags: -ngl 99 full GPU offload; --jinja use the model's
+        # embedded chat template; ttl 1800 frees all VRAM after 30 min idle.
+        # Sampling flags follow each model card.
+        models = {
+          "ornith-1.0-9b" = {
+            # -np 4: four parallel slots; -c 98304 is the total KV budget, so
+            # each slot gets 24576 tokens of context.
+            cmd = "${llama-server} --port \${PORT} -m ${ornith} -ngl 99 -c 98304 -np 4 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
+            aliases = ["ornith"];
+            ttl = 1800;
+          };
+          "qwen3.5-9b" = {
+            cmd = "${llama-server} --port \${PORT} -m ${qwen} -ngl 99 -c 40960 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
+            aliases = ["qwen"];
+            ttl = 1800;
+          };
+          "gemma-4-12b" = {
+            cmd = "${llama-server} --port \${PORT} -m ${gemma} -ngl 99 -c 32768 --jinja --temp 1.0 --top-p 0.95 --top-k 64";
+            aliases = ["gemma"];
+            ttl = 1800;
+          };
+          "nemotron-nano-12b-v2" = {
+            cmd = "${llama-server} --port \${PORT} -m ${nemotron} -ngl 99 -c 32768 --jinja --temp 0.6 --top-p 0.95";
+            aliases = ["nemotron"];
+            ttl = 1800;
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary
- Add three llama-swap models on artemis, hash-pinned into the nix store like ornith:
  - `qwen3.5-9b` — unsloth/Qwen3.5-9B-GGUF Q8_0 (9.5 GB), alias `qwen`
  - `gemma-4-12b` — unsloth/gemma-4-12b-it-GGUF Q6_K (9.8 GB), alias `gemma`
  - `nemotron-nano-12b-v2` — bartowski/nvidia_NVIDIA-Nemotron-Nano-12B-v2-GGUF Q6_K (10.1 GB), alias `nemotron`
- Bump ornith to `-np 4 -c 98304` (4 parallel slots, 24576 tokens each)

All models keep the existing pattern: `-ngl 99`, `--jinja`, model-card sampling defaults, 30-min TTL unload. Hashes taken from HuggingFace LFS metadata.

## Test plan
- `nix eval .#nixosConfigurations.artemis.config.services.llama-swap.settings` renders the expected YAML with `${PORT}` left literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)