### PR TITLE
feat(attic): bump fork to trusted-write main, grant tw to CI and writers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1785937871,
-        "narHash": "sha256-f7pYCDvTP45rBmoK8eEY9kCDRPtDBZ7ICZ4ra9bWXXY=",
+        "lastModified": 1785943159,
+        "narHash": "sha256-TewMVJWB5eDoQZ0MH6ceaBof6cywnaWMW9Sz6M6NQq4=",
         "owner": "jeiang",
         "repo": "attic",
-        "rev": "3d8528c314504b2abeb0d098fc82ce65b991789b",
+        "rev": "78022d13360929ed6d54007c48919f4904c3bb3b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1784469122,
-        "narHash": "sha256-VB89AS4wmRYeBl4bw05NwsNMUe8r+tGJGW/KgxEnpP4=",
+        "lastModified": 1785937871,
+        "narHash": "sha256-f7pYCDvTP45rBmoK8eEY9kCDRPtDBZ7ICZ4ra9bWXXY=",
         "owner": "jeiang",
         "repo": "attic",
-        "rev": "7e0a356cf10ed1a6b4bb5b565faed8be35d5607e",
+        "rev": "3d8528c314504b2abeb0d098fc82ce65b991789b",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/attic/default.nix
+++ b/modules/nixos/attic/default.nix
@@ -37,11 +37,7 @@
     # `caches` keys, not the permission attrset nested inside `caches`.
     # This assertion is the only thing standing between a typo here and a
     # silently-empty OIDC grant.
-    # ponytail: "tw" (trusted-write) deliberately absent -- jeiang/attic PR
-    # #24 is still open, so the pinned rev has no such key and whitelisting
-    # it would recreate the silent-empty-grant hazard. Add "tw" (and its
-    # grants) only after that PR merges and the input is re-bumped.
-    validAtticCachePermissionKeys = ["r" "w" "d" "cc" "cr" "cq" "cd" "b"];
+    validAtticCachePermissionKeys = ["r" "w" "d" "cc" "cr" "cq" "cd" "b" "tw"];
 
     oidcCachePermissionKeyErrors =
       lib.concatMap (
@@ -182,9 +178,15 @@
                   repository_owner_id = "31970261";
                   ref_protected = "true";
                 };
+                # tw (trusted-write) supplements w, it doesn't replace it:
+                # it skips server-side verification on push (client-attested
+                # chunks, spot-verified within ~1 GC cycle), so it's
+                # root-equivalent for data integrity in this cache. Only
+                # protected-ref CI and the pocketid admin/writer roles hold it.
                 caches.default = {
                   r = 1;
                   w = 1;
+                  tw = 1;
                   d = 0;
                   cc = 0;
                   cr = 0;
@@ -223,6 +225,7 @@
                 caches."*" = {
                   r = 1;
                   w = 1;
+                  tw = 1;
                   d = 1;
                   cc = 1;
                   cr = 1;
@@ -235,6 +238,7 @@
                 caches."*" = {
                   r = 1;
                   w = 1;
+                  tw = 1;
                   d = 0;
                   cc = 0;
                   cr = 0;

--- a/modules/nixos/attic/default.nix
+++ b/modules/nixos/attic/default.nix
@@ -37,7 +37,11 @@
     # `caches` keys, not the permission attrset nested inside `caches`.
     # This assertion is the only thing standing between a typo here and a
     # silently-empty OIDC grant.
-    validAtticCachePermissionKeys = ["r" "w" "d" "cc" "cr" "cq" "cd"];
+    # ponytail: "tw" (trusted-write) deliberately absent -- jeiang/attic PR
+    # #24 is still open, so the pinned rev has no such key and whitelisting
+    # it would recreate the silent-empty-grant hazard. Add "tw" (and its
+    # grants) only after that PR merges and the input is re-bumped.
+    validAtticCachePermissionKeys = ["r" "w" "d" "cc" "cr" "cq" "cd" "b"];
 
     oidcCachePermissionKeyErrors =
       lib.concatMap (


### PR DESCRIPTION
Bumps jeiang/attic 7e0a356 → 78022d1 (two commits: pre-merge main with browse `b`, then post-[jeiang/attic#24](https://github.com/jeiang/attic/pull/24) main with trusted-write).

## Changes
- `attic` flake input → `78022d1`: trusted-write (`tw`) permission, `chunk.verified_at` migration + spot-verifier, `object.nar_id` index, stale-pending GC sweep, browse commands, P1 stall fixes. CI's pinned client follows `flake.lock` automatically.
- `validAtticCachePermissionKeys` += `b`, `tw` (both verified present in the pinned rev's `CachePermission`).
- `tw = 1` alongside `w = 1` in the GitHub-Actions `ref_protected` rule and the pocketid admin/writer rules. Reader and unprotected-ref rules unchanged — `tw` is root-equivalent for data integrity in caches it can write to.

## First start after deploy
- Startup migrations run (verified_at backfill over the whole chunk table on Supabase) — expect a slower first start.
- Watch stderr for `Reset holders_count on N NAR(s)…` (past OOM-kill leaks healing) and GC's `Deleted N stale pending NARs/chunks`.

## Verification
- narinfo: `public, max-age=300`, `URL:` field `nar/<64-hex>.nar`; that NAR URL: `public, max-age=31536000, immutable` + Content-Length.
- After a CI push: `SELECT count(*) FROM chunk WHERE state='V' AND verified_at IS NULL;` — >0 right after the push proves the trusted path engaged; drains to 0 within a GC cycle (≤12h).
- Large push + simultaneous pull: downloads should no longer stall.

Cloudflare orange-cloud for attic.jeiang.dev only after the above passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)