### PR TITLE
feat(hosts): install the Claude Code CLI on artemis and zakkart

### DIFF
--- a/modules/darwin/apps.nix
+++ b/modules/darwin/apps.nix
@@ -27,6 +27,10 @@
         # CLI
         bat
         btop
+        # The CLI, separate from the "claude" desktop cask in
+        # modules/darwin/homebrew.nix. nixpkgs disables its self-updater,
+        # so it tracks this flake's nixpkgs input.
+        claude-code
         defaultbrowser
         erdtree
         # withWhisper defaults on for ffmpeg-full >=8.0 (whisper speech

--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -104,6 +104,14 @@
             directory = ".local/share/keyrings";
             mode = "0700";
           }
+          {
+            # Claude Code's whole per-user state tree: settings.json,
+            # memory/, skills/, plugins/, per-project session history and
+            # todos — and .credentials.json, the OAuth tokens it writes
+            # here on Linux (no system keychain), hence 0700 like .ssh.
+            directory = ".claude";
+            mode = "0700";
+          }
           ".local/share/fish"
           ".local/share/direnv"
           ".local/share/devenv"
@@ -124,7 +132,16 @@
           ".local/share/qBittorrent"
           ".local/share/rivalsmodmanager"
         ];
+        # ~/.claude.json is Claude Code's global config file (onboarding
+        # state, per-project trust/history, MCP server entries) and sits
+        # next to ~/.claude rather than inside it. impermanence creates an
+        # empty file at this path if /persist has none yet; Claude Code
+        # treats an unparseable config as a fresh one (it moves it aside to
+        # ~/.claude.json.corrupted) rather than failing to start.
+        data.files = [".claude.json"];
         cache.directories = [
+          # Per-project MCP server logs; regenerated, safe to lose.
+          ".cache/claude-cli-nodejs"
           ".cache/devenv"
           ".cache/direnv"
           ".cache/nix-direnv"
@@ -167,6 +184,13 @@
           helpers.kernelModuleLLVMOverride (pkgs.linuxKernel.packagesFor kernel);
         blacklistedKernelModules = ["algif_aead"];
       };
+      # Claude Code, here rather than in the shared toolbox
+      # (modules/nixos/toolbox.nix) — it's a workstation tool, not
+      # something the legion nodes need. The nixpkgs derivation already
+      # pins the CLI's own updater off (DISABLE_AUTOUPDATER), so it stays
+      # on whatever version this flake's nixpkgs input carries. Its state
+      # lives in ~/.claude and ~/.claude.json, both persisted above.
+      environment.systemPackages = [pkgs.claude-code];
       environment.variables = {
         AMD_VULKAN_ICD = "RADV";
         MESA_SHADER_CACHE_MAX_SIZE = "12G";


### PR DESCRIPTION
Adds `pkgs.claude-code` (2.1.212 from the pinned nixpkgs; unfree is already allowed on both hosts) to artemis and zakkart.

## artemis — `modules/hosts/artemis/default.nix`

- `environment.systemPackages = [pkgs.claude-code]` on the host rather than in `modules/nixos/toolbox.nix`, so the legion nodes do not pick it up.
- Persistence, since `nukeRoot` wipes anything unlisted on every boot:
  - `.claude` as a `0700` data directory — on Linux the CLI writes its OAuth tokens to `.claude/.credentials.json` (no system keychain), alongside settings, memory, skills, plugins and per-project session history.
  - `.claude.json` as a data **file** (first use of `data.files` on this host; the option and `migrate-persist.sh` both already handle it).
  - `.cache/claude-cli-nodejs` as cache — regenerated MCP logs.

## zakkart — `modules/darwin/apps.nix`

`claude-code` in the CLI list, distinct from the existing `claude` desktop cask in `modules/darwin/homebrew.nix`.

## Notes

The nixpkgs wrapper already sets `DISABLE_AUTOUPDATER=1`, so the CLI stays on whatever version this flake's nixpkgs input carries instead of self-updating out of the store.

## Verification

- `nix eval` of both `nixosConfigurations.artemis` and `darwinConfigurations.zakkart` succeeds.
- `claude-code-2.1.212` appears in artemis' `systemPackages`; the persistence entries resolve to `/home/aidanp/.claude.json` and `/home/aidanp/.cache/claude-cli-nodejs`.
- treefmt/statix/editorconfig clean (pre-commit hooks passed).
- Not deployed, and `just check` was not run.

## Before rebooting artemis

impermanence never migrates existing state, so run this on artemis against this checkout before the next boot:

```
sudo ./modules/hosts/artemis/migrate-persist.sh /path/to/flake-checkout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)