### PR TITLE
fix(edge): trust Cloudflare so CrowdSec bans clients, not PoPs

### DIFF
--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -145,6 +145,40 @@
           # only the metrics output, nothing administrative.
           metrics
 
+          # Cloudflare sits in front of every orange-clouded hostname here, so
+          # without this Caddy treats Cloudflare's edge as the client: every
+          # access record carries a Cloudflare IP as `client_ip`, and every
+          # CrowdSec decision derived from one bans a Cloudflare PoP rather
+          # than the actual client.
+          #
+          # That is not merely useless, it is an outage: a single probe from
+          # one attacker (observed: an Amazonbot `/media../.env` request to
+          # auth.jeiang.dev tripping crowdsecurity/appsec-vpatch) bans a shared
+          # Cloudflare address, which then 403s every unrelated visitor routed
+          # through that PoP, across every proxied hostname. It is what made
+          # the binary cache unreachable from GitHub Actions -- `nix` logged
+          # `unable to download '.../nix-cache-info': HTTP error 403` and fell
+          # back to building from source on every CI run.
+          #
+          # Both decision paths honour this once set: the bouncer resolves the
+          # client through Caddy's own ClientIPVarKey
+          # (caddy-crowdsec-bouncer internal/httputils, "the client IP
+          # reported here is the actual client IP"), and the hub's
+          # crowdsecurity/caddy-logs parser reads
+          # `evt.Unmarshaled.caddy.request.client_ip`.
+          #
+          # The range list comes from the `cloudflare` ip_source module
+          # (github.com/WeidiDeng/caddy-cloudflare-ip, modules/packages/caddy.nix)
+          # rather than a static list in Nix, so a Cloudflare range change does
+          # not silently reintroduce this by going stale.
+          servers {
+            trusted_proxies cloudflare {
+              interval 12h
+              timeout 15s
+            }
+            client_ip_headers Cf-Connecting-Ip
+          }
+
           ${lib.optionalString cfg.crowdsec.enable ''
             # Handler ordering: neither the `crowdsec` nor `appsec` HTTP
             # handler directive registers a position in Caddy's default

--- a/modules/packages/caddy.nix
+++ b/modules/packages/caddy.nix
@@ -3,10 +3,16 @@
     packages.caddy = pkgs.caddy.withPlugins {
       plugins = [
         "github.com/caddy-dns/cloudflare@v0.2.4"
+        # Cloudflare IP ranges as a `trusted_proxies` source, so Caddy
+        # resolves the real client from Cf-Connecting-Ip instead of treating
+        # Cloudflare's edge as the client (modules/nixos/edge/default.nix).
+        # Distinct from caddy-dns/cloudflare above, which is only the ACME DNS
+        # provider. Pinned to a commit because upstream publishes no tags.
+        "github.com/WeidiDeng/caddy-cloudflare-ip@f53b62aa13cb7ad79c8b47aacc3f2f03989b67e5"
         "github.com/hslatman/caddy-crowdsec-bouncer/http@v0.13.1"
         "github.com/hslatman/caddy-crowdsec-bouncer/appsec@v0.13.1"
       ];
-      hash = "sha256-X1YNG6q0zCxxfix5zTB2keuJXhY38q7lGIgvAPOk3WA=";
+      hash = "sha256-iIhqKvHlj/6LXXNl3tWysiwP8sW8wwuulk4BejRpJWU=";
       # withPlugins' default installCheckPhase matches plugin specs against
       # `caddy build-info` by full import path, but the CrowdSec bouncer's
       # http/appsec plugins share one go.mod at the repo root, so build-info


### PR DESCRIPTION
Caddy has no `trusted_proxies`, so on every orange-clouded hostname it treats Cloudflare's edge as the client. Every access record carries a Cloudflare IP as `client_ip`, and every CrowdSec decision derived from one bans a **Cloudflare PoP** rather than the actual client.

## Why this is an outage, not just a no-op

A single probe from a single attacker bans a shared Cloudflare address, which then 403s every unrelated visitor routed through that PoP — across `auth`, `budget`, `grafana`, `netbird`, `attic`, all of them.

Observed live. All ten active decisions were AS13335 CLOUDFLARENET:

```
│ 216 │ Ip:172.71.195.35  │ crowdsecurity/appsec-vpatch │ ban │ US │ 13335 CLOUDFLARENET │
│ 215 │ Ip:104.22.93.14   │ crowdsecurity/appsec-vpatch │ ban │ US │                     │
│ 214 │ Ip:172.68.23.167  │ crowdsecurity/appsec-vpatch │ ban │ US │ 13335 CLOUDFLARENET │
```

…triggered by requests like this one, where the real client is plainly visible in a header Caddy was not told to trust:

```json
"remote_ip":"172.70.34.120", "client_ip":"172.70.34.120",
"Cf-Connecting-Ip":["8.234.142.75"],
"User-Agent":["Mozilla/5.0 (compatible; Amazonbot/0.1; ...)"],
"uri":"/media../.env", "status":403
```

The real attacker is never banned and simply retries through another PoP.

## It is also why CI has had no cache

`nix` logged `unable to download .../nix-cache-info: HTTP error 403` and rebuilt from source. Yesterday's `main` run fetched **0** paths from attic and 525 from cache.nixos.org — CI has been running with an effectively dead cache, which is a large part of why those runs take 1–2 hours.

## The fix

Global `servers { trusted_proxies cloudflare { ... } client_ip_headers Cf-Connecting-Ip }`.

Both decision paths honour it, so AppSec and log-based scenarios are fixed together — verified in the sources rather than assumed:

- the bouncer resolves the client through Caddy's `ClientIPVarKey` (`caddy-crowdsec-bouncer` `internal/httputils`, whose own comment reads "the client IP reported here is the actual client IP");
- the hub's `crowdsecurity/caddy-logs` parser reads `evt.Unmarshaled.caddy.request.client_ip`, above a comment noting Caddy sets it once trusted proxies are configured.

Ranges come from the `cloudflare` ip_source module (`github.com/WeidiDeng/caddy-cloudflare-ip`) rather than a static list in Nix, so a Cloudflare range change cannot silently reintroduce this by going stale. Pinned to a commit because upstream publishes no tags.

## Verification

- `caddy list-modules` on the rebuilt package reports `http.ip_sources.cloudflare`.
- `caddy adapt` produces `trusted_proxies: {source: cloudflare, interval: 12h, timeout: 15s}` and `client_ip_headers: [Cf-Connecting-Ip]`.
- `legion-node1` evaluates.

## After deploying

Existing bans on Cloudflare IPs persist until they expire (or `cscli decisions delete`). Worth clearing them so the 403s stop immediately rather than over the next few hours.

Once real client IPs are visible, CrowdSec will start banning real clients — including CI runners if they trip a scenario. The existing `jeiang/attic-cache-whitelist` parser covers the cache hostnames by FQDN, which should hold, but the blast radius genuinely changes and is worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)