### PR TITLE
fix(secrets): restart consumers on rotation, guard Volume ownership

### DIFF
--- a/modules/nixos/attic/default.nix
+++ b/modules/nixos/attic/default.nix
@@ -290,12 +290,20 @@
       # EnvironmentFile is read by systemd (PID 1, root) before it drops
       # privileges to the dynamically allocated UID; it never needs to be
       # readable by a named service user.
-      templates."attic.env".content = ''
-        ATTIC_SERVER_DATABASE_URL=${config.sops.placeholder."attic/database-url"}
-        AWS_ACCESS_KEY_ID=${config.sops.placeholder."attic/s3-access-key-id"}
-        AWS_SECRET_ACCESS_KEY=${config.sops.placeholder."attic/s3-secret-access-key"}
-        ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64=${config.sops.placeholder."attic/token-rs256-secret-base64"}
-      '';
+      #
+      # restartUnits: an EnvironmentFile is read once at start-up and a
+      # secret-only deploy leaves the unit byte-identical, so without this
+      # atticd keeps using the pre-rotation credentials (see
+      # modules/nixos/garret/default.nix for the observed failure).
+      templates."attic.env" = {
+        restartUnits = ["atticd.service"];
+        content = ''
+          ATTIC_SERVER_DATABASE_URL=${config.sops.placeholder."attic/database-url"}
+          AWS_ACCESS_KEY_ID=${config.sops.placeholder."attic/s3-access-key-id"}
+          AWS_SECRET_ACCESS_KEY=${config.sops.placeholder."attic/s3-secret-access-key"}
+          ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64=${config.sops.placeholder."attic/token-rs256-secret-base64"}
+        '';
+      };
     };
   };
 }

--- a/modules/nixos/edge/default.nix
+++ b/modules/nixos/edge/default.nix
@@ -474,6 +474,11 @@
       sops.templates."caddy.env" = {
         owner = config.services.caddy.user;
         group = config.services.caddy.group;
+        # An EnvironmentFile is read once at start-up, and a deploy that
+        # only rotates a secret leaves the unit definition byte-identical
+        # -- so without this Caddy keeps using the pre-rotation token/key.
+        # Same reasoning as modules/nixos/garret/default.nix's templates.
+        restartUnits = ["caddy.service"];
         content =
           "CLOUDFLARE_API_TOKEN=${config.sops.placeholder."caddy/cloudflare-dns-token"}\n"
           + lib.optionalString cfg.crowdsec.enable ''

--- a/modules/nixos/garret/default.nix
+++ b/modules/nixos/garret/default.nix
@@ -174,15 +174,15 @@
       # create -- so without this they cannot create the database and exit
       # with SQLite error 14.
       #
-      # Deliberately NOT the `systemd.tmpfiles.rules` entry that
-      # modules/nixos/hath.nix and netbird-server/default.nix use for the
-      # same job: systemd-tmpfiles-setup.service is not ordered after this
+      # Deliberately NOT a `systemd.tmpfiles.rules` entry:
+      # systemd-tmpfiles-setup.service is not ordered after this
       # Volume's mount unit, so on the activation that first mounts the
       # Volume it runs against the empty pre-mount directory and the mount
-      # then hides its work (observed on the first legion-node4 deploy;
-      # those other services only escaped it because their Volumes were
-      # already mounted and owned from an earlier deploy). An ExecStartPre
-      # instead inherits the unit's own `RequiresMountsFor`, so it cannot
+      # then hides its work (observed on the first legion-node4 deploy).
+      # modules/nixos/hath.nix and netbird-server/default.nix used to use
+      # tmpfiles here and only escaped it because their Volumes were
+      # already mounted and owned from an earlier deploy; both now use this
+      # same ExecStartPre shape. An ExecStartPre inherits the unit's own `RequiresMountsFor`, so it cannot
       # run before the mount exists, and it re-asserts ownership on every
       # start -- which also covers replacing or reformatting the Volume.
       #

--- a/modules/nixos/hath.nix
+++ b/modules/nixos/hath.nix
@@ -26,10 +26,6 @@
       group = "hath";
     };
 
-    # External prerequisite (Volume mount): this only fixes ownership/mode
-    # once it exists, same pattern as modules/nixos/netbird-server/default.nix.
-    systemd.tmpfiles.rules = ["d ${dataDir} 0750 hath hath - -"];
-
     # Mount guard (flake.lib.mountGuard, modules/hosts/legion/default.nix)
     # merged in via `//`: refuse to start unless ${dataDir} is actually
     # mounted, so a missing/late Volume never silently initializes fresh
@@ -58,6 +54,18 @@
             "--disable-ip-origin-check"
             "--enable-metrics"
           ];
+          # Ownership of the Volume root (external prerequisite; the
+          # runbook can copy content in as root and hand it to the service
+          # user). An ExecStartPre, NOT `systemd.tmpfiles.rules`:
+          # systemd-tmpfiles-setup.service is not ordered after this
+          # Volume's mount unit, so on the activation that first mounts the
+          # Volume a tmpfiles rule runs against the empty pre-mount
+          # directory and the mount then hides its work. This inherits the
+          # unit's own `RequiresMountsFor` (mountGuard below), so it cannot
+          # run before the mount exists. Same reasoning and same shape as
+          # modules/nixos/garret/default.nix's `ensureDataDir`; `+` runs it
+          # as root despite User=hath.
+          ExecStartPre = "+${pkgs.coreutils}/bin/install -d -o hath -g hath -m 0750 ${dataDir}";
           Restart = "on-failure";
           RestartSec = 5;
           User = "hath";

--- a/modules/nixos/hermes/default.nix
+++ b/modules/nixos/hermes/default.nix
@@ -610,11 +610,21 @@
       # DynamicUser, unlike modules/nixos/attic.nix's atticd -- so a named
       # owner is meaningful and needed for the preStart script above to
       # read the codex-auth.json secret as that same user).
+      #
+      # restartUnits: this is read once at agent start-up (merged into
+      # $HERMES_HOME/.env at activation), and a deploy that only rotates a
+      # token leaves the unit definition byte-identical -- so without it
+      # the running agent keeps using the pre-rotation credentials. Only
+      # hermes-agent.service: hermes-kb-sync and hermes-vdirsyncer-sync are
+      # timer-driven oneshots that read the file fresh on their next run,
+      # and listing them here would instead fire a sync on every deploy.
+      # See modules/nixos/garret/default.nix for the observed failure.
       "hermes/env" = {
         inherit sopsFile;
         owner = cfg.user;
         inherit (cfg) group;
         mode = "0400";
+        restartUnits = ["hermes-agent.service"];
       };
       # Codex-CLI-format OAuth seed, copied into
       # ${cfg.stateDir}/.codex/auth.json by the preStart script above; see
@@ -632,11 +642,18 @@
       # (docs/runbooks/hermes.md); the matching public half is already
       # committed at modules/nixos/hermes-ops/default.nix's
       # `authorizedKeys`.
+      # restartUnits: the preStart installs this unconditionally, so a
+      # restart is what actually propagates a rotated key to
+      # ${sshDir}/id_ed25519. (`hermes/codex-auth.json` above deliberately
+      # gets none: its preStart copy is guarded by `[ ! -f ]`, so a restart
+      # would not replace an existing file anyway -- rotating that one is a
+      # runbook step, docs/runbooks/hermes.md.)
       "hermes/ssh-key" = {
         inherit sopsFile;
         owner = cfg.user;
         inherit (cfg) group;
         mode = "0400";
+        restartUnits = ["hermes-agent.service"];
       };
     };
 

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -823,15 +823,23 @@
         # alertmanager/discord-webhook below -- this needs an explicit
         # owner: the default sops-nix mode (0400, root-owned) would
         # otherwise be unreadable by the `grafana` user.
+        # restartUnits throughout this block: every one of these is read
+        # once at process start-up (Grafana's `$__file{}` provider, or
+        # systemd's EnvironmentFile), and a deploy that only rotates the
+        # secret leaves the unit definition byte-identical -- so without it
+        # the running process keeps using the pre-rotation value. See
+        # modules/nixos/garret/default.nix for the observed failure.
         "grafana/secret-key" = {
           inherit sopsFile;
           owner = "grafana";
+          restartUnits = ["grafana.service"];
         };
         "alertmanager/discord-webhook" = {inherit sopsFile;};
       };
       templates = {
         "grafana.env" = {
           owner = "grafana";
+          restartUnits = ["grafana.service"];
           content = "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${config.sops.placeholder."grafana/oauth-client-secret"}\n";
         };
         # No owner override: alertmanager runs with DynamicUser (nixpkgs
@@ -839,7 +847,10 @@
         # `netbird-relay.env` template -- EnvironmentFile is read by
         # systemd (PID 1, root) before the unit's dynamic user is
         # allocated, so the sops-nix default owner (root) is sufficient.
-        "alertmanager.env".content = "DISCORD_WEBHOOK_URL=${config.sops.placeholder."alertmanager/discord-webhook"}\n";
+        "alertmanager.env" = {
+          restartUnits = ["alertmanager.service"];
+          content = "DISCORD_WEBHOOK_URL=${config.sops.placeholder."alertmanager/discord-webhook"}\n";
+        };
       };
     };
 

--- a/modules/nixos/netbird-server/default.nix
+++ b/modules/nixos/netbird-server/default.nix
@@ -101,14 +101,25 @@
         "netbird/idp-session-cookie-encryption-key" = {inherit sopsFile;};
       };
 
+      # restartUnits on both: the config file is read once at start-up
+      # (--config) and the EnvironmentFile once by systemd, while a deploy
+      # that only rotates a secret leaves both unit definitions
+      # byte-identical -- so without this the running processes keep the
+      # pre-rotation values, and the relay's NB_AUTH_SECRET would silently
+      # disagree with the server's `relays.secret`. See
+      # modules/nixos/garret/default.nix for the observed failure.
       templates = {
         "netbird-server-config.yaml" = {
           owner = "netbird";
           group = "netbird";
+          restartUnits = ["netbird-server.service"];
           content = configYaml;
         };
 
-        "netbird-relay.env".content = "NB_AUTH_SECRET=${config.sops.placeholder."netbird/relay-auth-secret"}\n";
+        "netbird-relay.env" = {
+          restartUnits = ["netbird-relay.service"];
+          content = "NB_AUTH_SECRET=${config.sops.placeholder."netbird/relay-auth-secret"}\n";
+        };
       };
     };
 
@@ -119,12 +130,6 @@
     };
 
     systemd = {
-      # The Volume mount itself is an external prerequisite (see `dataDir`
-      # above); this only fixes ownership/mode once it exists, so the
-      # runbook can copy PVC content in as root and hand it to the service
-      # user.
-      tmpfiles.rules = ["d ${dataDir} 0750 netbird netbird - -"];
-
       services = {
         # Mount guard (flake.lib.mountGuard, modules/hosts/legion/default.nix)
         # merged in via `//`: refuse to start unless ${dataDir} is
@@ -139,6 +144,19 @@
             wantedBy = ["multi-user.target"];
             serviceConfig = {
               ExecStart = "${lib.getExe serverPkg} --config ${config.sops.templates."netbird-server-config.yaml".path}";
+              # Ownership of the Volume root (external prerequisite, see
+              # `dataDir` above), so the runbook can copy PVC content in as
+              # root and hand it to the service user. An ExecStartPre, NOT
+              # `systemd.tmpfiles.rules`: systemd-tmpfiles-setup.service is
+              # not ordered after this Volume's mount unit, so on the
+              # activation that first mounts the Volume a tmpfiles rule
+              # runs against the empty pre-mount directory and the mount
+              # then hides its work. This inherits the unit's own
+              # `RequiresMountsFor` (mountGuard below), so it cannot run
+              # before the mount exists. Same reasoning and same shape as
+              # modules/nixos/garret/default.nix's `ensureDataDir`; `+`
+              # runs it as root despite User=netbird.
+              ExecStartPre = "+${pkgs.coreutils}/bin/install -d -o netbird -g netbird -m 0750 ${dataDir}";
               Restart = "on-failure";
               RestartSec = 5;
               User = "netbird";

--- a/modules/nixos/netbird-server/proxy.nix
+++ b/modules/nixos/netbird-server/proxy.nix
@@ -107,12 +107,23 @@
         # modules/nixos/crowdsec/default.nix under the bouncer name
         # "legion-node2-firewall". Same crowdsec shard as the bouncer key
         # above.
-        "crowdsec/bouncer-legion-node2-firewall" = {sopsFile = crowdsecSopsFile;};
+        # Read once at start-up by the bouncer process; a secret-only
+        # deploy leaves the unit byte-identical, so without restartUnits a
+        # rotated key means the bouncer keeps presenting the old one and
+        # the LAPI starts rejecting it. Same reasoning as
+        # modules/nixos/garret/default.nix.
+        "crowdsec/bouncer-legion-node2-firewall" = {
+          sopsFile = crowdsecSopsFile;
+          restartUnits = ["crowdsec-firewall-bouncer.service"];
+        };
       };
 
       templates = {
         "netbird-proxy.env" = {
           owner = "netbird-proxy";
+          # EnvironmentFile, read once at start-up -- see the bouncer key
+          # above for why a secret-only deploy needs this to take effect.
+          restartUnits = ["netbird-proxy.service"];
           content = ''
             NB_PROXY_TOKEN=${config.sops.placeholder."netbird/proxy-token"}
             NB_PROXY_CROWDSEC_API_KEY=${config.sops.placeholder."crowdsec/bouncer-netbird-proxy-key"}

--- a/modules/nixos/pocket-id/default.nix
+++ b/modules/nixos/pocket-id/default.nix
@@ -7,7 +7,11 @@
   # only for the inventory node that places `pocket-id`
   # (modules/hosts/legion/default.nix, same optional-import pattern as
   # netbird-server/netbird-proxy).
-  flake.nixosModules.pocket-id = {config, ...}: let
+  flake.nixosModules.pocket-id = {
+    config,
+    pkgs,
+    ...
+  }: let
     # legion-node2's declared Volume mountpoint
     # (modules/hosts/legion/_service-inventory.nix pocket-id.volume).
     # WorkingDirectory=dataDir (nixpkgs' services.pocket-id systemd unit),
@@ -63,7 +67,23 @@
         # Overrides the nixpkgs services.pocket-id unit (fixed "pocket-id"
         # user, not DynamicUser), same as every other MemoryMax override in
         # this repo.
-        serviceConfig.MemoryMax = "256M";
+        # The nixpkgs module owns ${dataDir} with its own
+        # `systemd.tmpfiles.rules` entry ("d ${dataDir} 0755 pocket-id
+        # pocket-id"), which is unsafe for a Volume mountpoint:
+        # systemd-tmpfiles-setup.service is not ordered after the mount
+        # unit, so on the activation that first mounts the Volume it runs
+        # against the empty pre-mount directory and the mount then hides
+        # its work (observed on the first legion-node4 deploy for garret).
+        # That rule can't be removed from here, so re-assert the same
+        # ownership and mode from an ExecStartPre, which inherits this
+        # unit's own `RequiresMountsFor` (mountGuard below) and therefore
+        # cannot run before the mount exists. Same shape as
+        # modules/nixos/garret/default.nix's `ensureDataDir`; `+` runs it
+        # as root despite the unit's User=pocket-id.
+        serviceConfig = {
+          MemoryMax = "256M";
+          ExecStartPre = "+${pkgs.coreutils}/bin/install -d -o pocket-id -g pocket-id -m 0755 ${dataDir}";
+        };
       }
       // self.lib.mountGuard dataDir;
 
@@ -74,6 +94,11 @@
       };
       templates."pocket-id.env" = {
         owner = config.services.pocket-id.user;
+        # An EnvironmentFile is read once at start-up and a secret-only
+        # deploy leaves the unit byte-identical, so without this a rotated
+        # ENCRYPTION_KEY/STATIC_API_KEY never reaches the running process.
+        # See modules/nixos/garret/default.nix for the observed failure.
+        restartUnits = ["pocket-id.service"];
         content = ''
           ENCRYPTION_KEY=${config.sops.placeholder."pocket-id/encryption-key"}
           STATIC_API_KEY=${config.sops.placeholder."pocket-id/static-api-key"}


### PR DESCRIPTION
Two related deploy-time correctness bugs, both first observed on garret.

## 1. Secret rotation was a no-op for every service but garret

A deploy that only changes a secret leaves the consuming unit's definition byte-identical, so sops rewrites `/run/secrets` and the running process keeps using the pre-rotation value — the exact failure garret's signing key hit, where every path pushed after a key change kept the old signature and no consumer could verify it.

Every long-running consumer that reads its secret once at start-up now declares `restartUnits`:

| Host | Secret / template | Restarts |
|---|---|---|
| node1 | `caddy.env` | `caddy.service` |
| node2 | `netbird-server-config.yaml`, `netbird-relay.env`, `netbird-proxy.env`, `pocket-id.env`, `crowdsec/bouncer-legion-node2-firewall` | respective units |
| node3 | `grafana/secret-key`, `grafana.env`, `alertmanager.env`, `hermes/env`, `hermes/ssh-key` | `grafana`, `alertmanager`, `hermes-agent` |
| node4 | `attic.env` | `atticd.service` |

Deliberately left without `restartUnits`:

- **restic**, **hermes-kb-sync**, **hermes-vdirsyncer-sync** — timer-driven oneshots; they re-read on the next run, and listing them would fire a backup/sync on every deploy.
- **`netbird-proxy-cloudflare-dns.env`** — read by lego at renewal, not held by a process.
- **`hermes/codex-auth.json`** — its preStart copy is `[ ! -f ]`-guarded, so a restart wouldn't replace it; rotation is a runbook step.
- **`passwords/*`** (`neededForUsers`), **`netbird/setup-key`** (one-time join) — no long-running consumer.

## 2. tmpfiles-on-Volume audit

`hath` and `netbird-server` owned their Volume mountpoints with a `systemd.tmpfiles.rules` entry. `systemd-tmpfiles-setup.service` is not ordered after the mount unit, so on the activation that **first** mounts a Volume it runs against the empty pre-mount directory and the mount then hides its work. Both only escaped it because their Volumes were already mounted and owned from an earlier deploy. Both now use garret's `ExecStartPre`, which inherits the unit's own `RequiresMountsFor` and so cannot run before the mount exists.

Sweeping every `/mnt/*` rule across all five hosts turned up a **third** instance: `/mnt/pocket-id`, emitted by the nixpkgs `services.pocket-id` module itself. That rule can't be removed from here, so `pocket-id.service` re-asserts the same `0755 pocket-id:pocket-id` from an `ExecStartPre`, making the stale tmpfiles rule harmless. Nothing else left.

Garret's own comment is updated — it named hath and netbird-server as the counterexample.

## Known gap, not fixed here

Rotating `caddy/crowdsec-lapi-key` or the `crowdsec/bouncer-*` keys still won't re-register at the LAPI: `crowdsec-bouncers.service` skips any bouncer name that already exists. That needs a `cscli bouncers delete` first and is a separate fix.

## Verification

- All five `nixosConfigurations` evaluate.
- `nix flake check --impure` green (treefmt, statix, deploy-schema, deploy-activate).
- Effective `restartUnits` dumped per host via `nix eval` and matched against the table above.
- Confirmed `ExecStartPre` lands on hath/netbird-server/pocket-id, that no upstream `ExecStartPre` was clobbered, and that no `/mnt/*` tmpfiles rule survives on any host except the upstream pocket-id one.

Not deployed — eval/lint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)