### PR TITLE
perf(ci): stop paying for disk cleanup and duplicate closure downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ env:
   GARRET_SUBSTITUTER: https://cache.jeiang.dev
   GARRET_PUBLIC_KEY: "cache.jeiang.dev-1:owXJK5/UX9NSf1lhmDDT3QTxMtbVk9YfHhjvOXyPhpA="
 
+  # With the cache warm, a CI leg compiles almost nothing: it realises a few
+  # thousand already-built paths, so wall clock is substituter round-trips,
+  # not CPU. Nix's defaults (16 substitution jobs over 25 HTTP connections)
+  # leave the link mostly idle — the heavy legs were fetching ~2400 paths at
+  # roughly 6/s. These are the single biggest wall-clock knob left; they are
+  # also the knob that loads garret hardest, so they move together with its
+  # server-side limits.
+  MAX_SUBSTITUTION_JOBS: "32"
+  HTTP_CONNECTIONS: "64"
+
 jobs:
   # Source of the check matrix below. Building every check in a single job
   # previously ran for hours and got killed with no useful logs (likely OOM
@@ -55,11 +65,23 @@ jobs:
           extra_nix_config: |
             extra-substituters = ${{ env.GARRET_SUBSTITUTER }}
             extra-trusted-public-keys = ${{ env.GARRET_PUBLIC_KEY }}
+            max-substitution-jobs = ${{ env.MAX_SUBSTITUTION_JOBS }}
+            http-connections = ${{ env.HTTP_CONNECTIONS }}
 
+      # A matrix entry is a space-separated list of check names, not a single
+      # name, so related checks can share one runner. The only collapse today:
+      # deploy-schema and deploy-activate both realise every deploy node's
+      # activation profile — the same ~2200 paths, which already subsume all
+      # four legion toplevels — so as separate legs they paid ~400s each to
+      # download identical closures. Together, the second is free.
       - name: Discover checks
         id: discover
         run: |
-          checks=$(nix eval --json '.#checks.x86_64-linux' --apply builtins.attrNames)
+          collapse='
+            ([.[] | select(startswith("deploy-"))] | if length > 0 then [join(" ")] else [] end) as $deploy
+            | [.[] | select(startswith("deploy-") | not)] + $deploy
+          '
+          checks=$(nix eval --json '.#checks.x86_64-linux' --apply builtins.attrNames | jq -c "$collapse")
           echo "checks=$checks" >> "$GITHUB_OUTPUT"
 
   build:
@@ -73,10 +95,10 @@ jobs:
     strategy:
       fail-fast: false
       # 2 was set when every job compiled heavyweight closures from scratch;
-      # with the cache warm, jobs are mostly network-bound substitution, so a
-      # higher cap mainly trades cache server load for wall-clock time. Raise
-      # further if the cache keeps up.
-      max-parallel: 6
+      # with the cache warm, jobs are mostly network-bound substitution, so
+      # this cap just trades cache server load for wall-clock time. Raised to
+      # 10 once garret's server-side limits were lifted to match.
+      max-parallel: 10
       matrix:
         check: ${{ fromJson(needs.discover.outputs.checks) }}
     runs-on: ubuntu-latest
@@ -84,10 +106,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          df -h
+      # ponytail: no "free disk space" step. It was added (0b64642) when every
+      # check built in ONE job and needed headroom for all six closures at
+      # once; the matrix split made it vestigial. Each leg now realises a
+      # single check, entirely by substitution (~2400 paths, ~10-20 GB), on a
+      # 145 GB runner with ~70 GB free before any cleanup. It cost 25-190s per
+      # leg — 1709s across the matrix, 38% of all job-seconds, routinely
+      # longer than the build it was making room for. If a leg ever hits
+      # ENOSPC, add the rm -rf back to that leg only.
 
       # Pulls are anonymous against the public cache: baking the substituter
       # into nix.conf here means every nix invocation below substitutes from
@@ -98,15 +124,28 @@ jobs:
           extra_nix_config: |
             extra-substituters = ${{ env.GARRET_SUBSTITUTER }}
             extra-trusted-public-keys = ${{ env.GARRET_PUBLIC_KEY }}
+            max-substitution-jobs = ${{ env.MAX_SUBSTITUTION_JOBS }}
+            http-connections = ${{ env.HTTP_CONNECTIONS }}
 
       # print-out-paths emits one line per derivation output (e.g. mangohud's
       # "out" and "man"), so this can be multi-line — write it to
       # $GITHUB_OUTPUT with the delimiter form rather than a plain
       # key=value line, which breaks on embedded newlines.
+      #
+      # CHECKS is a space-separated list (see `discover`), and goes through
+      # the environment rather than being spliced into the script for the
+      # same reason PATHS does below. Building the whole group in one `nix
+      # build` rather than a loop is the point: nix then substitutes their
+      # shared dependencies once, concurrently, instead of once per attr.
       - name: Build check
         id: build
+        env:
+          CHECKS: ${{ matrix.check }}
+          SYSTEM: x86_64-linux
         run: |
-          paths=$(nix build --keep-going --show-trace --no-link --print-out-paths ".#checks.x86_64-linux.${{ matrix.check }}")
+          installables=()
+          for attr in $CHECKS; do installables+=(".#checks.${SYSTEM}.${attr}"); done
+          paths=$(nix build --keep-going --show-trace --no-link --print-out-paths "${installables[@]}")
           delimiter="$(openssl rand -hex 8)"
           {
             echo "paths<<$delimiter"
@@ -152,6 +191,11 @@ jobs:
   # per-check fan-out, so it's simpler as its own job than folded into that
   # matrix. Same pure `nix build` and best-effort cache push pattern as
   # `build` above.
+  #
+  # One attribute is all darwin needs, and a package fan-out here would be
+  # actively wasteful -- see the note in modules/checks.nix: the push below
+  # sends this toplevel's whole closure, which is already every darwin path
+  # zakkart installs.
   build-macos:
     permissions:
       contents: read
@@ -167,6 +211,8 @@ jobs:
           extra_nix_config: |
             extra-substituters = ${{ env.GARRET_SUBSTITUTER }}
             extra-trusted-public-keys = ${{ env.GARRET_PUBLIC_KEY }}
+            max-substitution-jobs = ${{ env.MAX_SUBSTITUTION_JOBS }}
+            http-connections = ${{ env.HTTP_CONNECTIONS }}
 
       - name: Build check
         id: build

--- a/modules/checks.nix
+++ b/modules/checks.nix
@@ -22,6 +22,16 @@
           '';
         }
       ))
+      # Deliberately just the toplevel, with no package-* fan-out mirroring the
+      # linux branch above. `garret push` sends a path's whole closure, so CI
+      # building this one attribute already seeds every darwin path zakkart
+      # installs. Measured 2026-08-07: of the 18 package checks darwin would
+      # expose, the 7 whose outputs were in garret were exactly the 7 inside
+      # this closure, and interior paths of it (btop, gmp, libaom,
+      # etc-100-nix-darwin.conf) were all present too. A fan-out would only add
+      # the packages zakkart does *not* install -- attic-server, caddy,
+      # netbird-{server,relay,proxy} -- NixOS service components that a macOS
+      # runner would compile from source and nothing would ever substitute.
       (lib.mkIf (system == "aarch64-darwin") {
         zakkart-system = self.darwinConfigurations.zakkart.config.system.build.toplevel;
       })

--- a/modules/deploy.nix
+++ b/modules/deploy.nix
@@ -4,6 +4,11 @@
   ...
 }: {
   flake = {
-    checks = builtins.mapAttrs (_system: deployLib: deployLib.deployChecks self.deploy) inputs.deploy-rs.lib;
+    # Only x86_64-linux: every deploy node is an x86_64-linux NixOS host, and
+    # these checks realise each node's activation profile (i.e. its NixOS
+    # toplevel), so the copies generated for every other system in
+    # deploy-rs.lib were unbuildable on those systems. CI never built them, but
+    # `nix flake check` on zakkart did try.
+    checks.x86_64-linux = inputs.deploy-rs.lib.x86_64-linux.deployChecks self.deploy;
   };
 }


### PR DESCRIPTION
CI ran ~18 min per PR with the cache warm, despite the builds themselves being
almost pure substitution. Most of that was overhead the matrix split made
obsolete.

Measured against run [31207021606](https://github.com/jeiang/.dotfiles/actions/runs/31207021606).

## Free disk space: removed

`free-disk-space` accounted for **1709s — 38% of all job-seconds** — and was
routinely longer than the build it was making room for:

```
 77s free /  38s build   package-git
 99s free /  22s build   package-netbird-proxy
189s free / 125s build   toplevel-legion-node4
```

It was added in 0b64642 when every check built in *one* job and needed headroom
for all six closures at once. The matrix split made it vestigial: each leg now
realises a single check by substitution (~2400 paths, ~10-20 GB) on a 145 GB
runner reporting 105 GB free *after* the deletion, so ~70 GB without it. If a
leg ever hits ENOSPC, the `rm -rf` goes back on that leg only.

## Substituter throughput

With the cache warm a leg compiles almost nothing, so wall clock is
round-trips, not CPU — the heavy legs were fetching ~2400 paths at roughly 6/s
under Nix's defaults (16 substitution jobs over 25 HTTP connections). Raised to
32/64, alongside `max-parallel` 6 → 10, now that garret's server-side limits
allow the throughput. Both are workflow-level `env`, so backing off is one line.

## deploy-* collapsed onto one runner

`deployChecks` interpolates each node's `profilePath` into the rendered config,
making every legion toplevel a build-time dependency. So `deploy-schema` and
`deploy-activate` realise **the same ~2200 paths** — 418s and 409s to download
identical closures. A matrix entry is now a space-separated *list* of check
names, and `discover` emits the pair as one entry. Second check is free.

The `toplevel-legion-*` legs are deliberately left alone even though
`deploy-activate` strictly subsumes them: folding them in saves job-seconds and
zero wall clock, at the cost of the per-host signal.

## deploy checks pinned to x86_64-linux

Separate from the perf work. These were generated for *every* system in
`deploy-rs.lib`, including `aarch64-darwin`, where they cannot build — they
realise NixOS activation profiles. CI never built them, but `nix flake check`
on zakkart did try.

## No darwin package fan-out

This started as "build aarch64-darwin so zakkart benefits from the cache." It
turned out zakkart already does: **`garret push` sends whole closures**, so the
existing `zakkart-system` job seeds every darwin path the Mac installs.

Verified against the live cache — of the 18 package checks darwin would expose,
the 7 whose outputs were in garret were exactly the 7 inside `zakkart-system`'s
closure (11 non-matches, no exceptions), and interior paths of that closure
(`btop`, `gmp`, `libaom`, `etc-100-nix-darwin.conf`) are all present too.
garret does not proxy upstream, so a hit there means genuinely pushed.

A fan-out would only have added the packages zakkart does *not* install —
`attic-server`, `caddy`, `netbird-{server,relay,proxy}` — NixOS service
components a macOS runner would compile from source and nothing would ever
substitute. Recorded in `modules/checks.nix` so it isn't re-derived.

## Expected

18 min → **~6-7 min**; linux job-seconds 4518 → ~1400. The substitution tuning
is the one unmeasured bet — it only shows up under real runner latency.

## Verification

- All 18 aarch64-darwin checks built locally: no failures.
- `actionlint` clean (3 info-level items, all pre-existing intentional word-splitting).
- `statix`, `treefmt`, `editorconfig-checker` pass.
- `discover` logic exercised locally: 28 checks → 27 legs, deploy pair collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)