### PR TITLE
perf(artemis): fetch llama-swap GGUFs at runtime, not into the store

### DIFF
--- a/modules/hosts/artemis/default.nix
+++ b/modules/hosts/artemis/default.nix
@@ -69,6 +69,11 @@
           "/var/lib/NetworkManager"
           "/var/lib/bluetooth"
           "/var/lib/netbird"
+          # GGUF weights fetched by llama-swap-models
+          # (modules/nixos/llama-swap.nix). Not derivable state: without this
+          # entry nukeRoot drops tens of GB of models on every boot and the
+          # unit re-downloads all of them before llama-swap can start.
+          "/var/lib/llama-swap-models"
         ];
 
         # User-level state.

--- a/modules/nixos/llama-swap.nix
+++ b/modules/nixos/llama-swap.nix
@@ -8,24 +8,42 @@ _: {
   }: let
     llama-cpp = pkgs.llama-cpp.override {vulkanSupport = true;};
     llama-server = lib.getExe' llama-cpp "llama-server";
-    # Models hash-pinned into the store so they survive reboots (nix store
-    # is persisted) with no impermanence entry.
-    ornith = pkgs.fetchurl {
-      url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF/resolve/main/ornith-1.0-9b-Q6_K.gguf";
-      hash = "sha256-M7b2o+PwUHhDjhLfiktVyKz3jOrcxjnSrxzzWgJug4c=";
+    # Models are fetched at runtime into a persisted directory rather than
+    # hash-pinned into the store. As `pkgs.fetchurl` results they were store
+    # paths referenced by each `cmd` below, which put 34 GB of GGUF inside
+    # nixos-system-artemis's closure: every CI leg and every deploy had to
+    # drag all of it over the wire just to prove the configuration evaluates,
+    # and it made toplevel-artemis the slowest job in the matrix by a factor
+    # of four.
+    #
+    # The store was doing three jobs here -- fetching, integrity, and
+    # surviving the nukeRoot reboot (via the persisted /nix). The unit below
+    # takes over the first two; the third needs the /var/lib/llama-swap-models
+    # entry in modules/hosts/artemis/default.nix `persistence.directories`,
+    # which is what the original "no impermanence entry" comment was avoiding.
+    # Without that entry every reboot re-downloads the lot.
+    modelDir = "/var/lib/llama-swap-models";
+    models = {
+      "ornith-1.0-9b-Q6_K.gguf" = {
+        url = "https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF/resolve/main/ornith-1.0-9b-Q6_K.gguf";
+        hash = "sha256-M7b2o+PwUHhDjhLfiktVyKz3jOrcxjnSrxzzWgJug4c=";
+      };
+      "Qwen3.5-9B-Q8_0.gguf" = {
+        url = "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf";
+        hash = "sha256-gJYmV00MtD1L7PpWFpmA2iu0SPIpknD3vkQ8uJ0KauQ=";
+      };
+      "gemma-4-12b-it-Q6_K.gguf" = {
+        url = "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q6_K.gguf";
+        hash = "sha256-bzlDNlALtUCb1owxqp11CXteYQT2zzDIKgmntk30H68=";
+      };
+      "nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf" = {
+        url = "https://huggingface.co/bartowski/nvidia_NVIDIA-Nemotron-Nano-12B-v2-GGUF/resolve/main/nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf";
+        hash = "sha256-ZZZhGQ2fZQrku6JS3jqI7Qu8tg67ToM8xtHbOWEEFtw=";
+      };
     };
-    qwen = pkgs.fetchurl {
-      url = "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf";
-      hash = "sha256-gJYmV00MtD1L7PpWFpmA2iu0SPIpknD3vkQ8uJ0KauQ=";
-    };
-    gemma = pkgs.fetchurl {
-      url = "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q6_K.gguf";
-      hash = "sha256-bzlDNlALtUCb1owxqp11CXteYQT2zzDIKgmntk30H68=";
-    };
-    nemotron = pkgs.fetchurl {
-      url = "https://huggingface.co/bartowski/nvidia_NVIDIA-Nemotron-Nano-12B-v2-GGUF/resolve/main/nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf";
-      hash = "sha256-ZZZhGQ2fZQrku6JS3jqI7Qu8tg67ToM8xtHbOWEEFtw=";
-    };
+    # A plain string, deliberately: interpolating a store path here is exactly
+    # what pulled the weights into the closure.
+    model = name: "${modelDir}/${name}";
   in {
     services.llama-swap = {
       enable = true;
@@ -43,7 +61,7 @@ _: {
         healthCheckTimeout = 300;
         # ${PORT} in each cmd is llama-swap's own macro (escaped with the
         # extra $ so Nix leaves it literal in the generated YAML), not a Nix
-        # interpolation like ${llama-server}/${ornith} etc.
+        # interpolation like ${llama-server}/${model "..."} etc.
         # Shared flags: -ngl 99 full GPU offload; --jinja use the model's
         # embedded chat template; ttl 1800 frees all VRAM after 30 min idle.
         # Sampling flags follow each model card.
@@ -51,27 +69,76 @@ _: {
           "ornith-1.0-9b" = {
             # -np 4: four parallel slots; -c 98304 is the total KV budget, so
             # each slot gets 24576 tokens of context.
-            cmd = "${llama-server} --port \${PORT} -m ${ornith} -ngl 99 -c 98304 -np 4 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
+            cmd = "${llama-server} --port \${PORT} -m ${model "ornith-1.0-9b-Q6_K.gguf"} -ngl 99 -c 98304 -np 4 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
             aliases = ["ornith"];
             ttl = 1800;
           };
           "qwen3.5-9b" = {
-            cmd = "${llama-server} --port \${PORT} -m ${qwen} -ngl 99 -c 40960 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
+            cmd = "${llama-server} --port \${PORT} -m ${model "Qwen3.5-9B-Q8_0.gguf"} -ngl 99 -c 40960 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
             aliases = ["qwen"];
             ttl = 1800;
           };
           "gemma-4-12b" = {
-            cmd = "${llama-server} --port \${PORT} -m ${gemma} -ngl 99 -c 32768 --jinja --temp 1.0 --top-p 0.95 --top-k 64";
+            cmd = "${llama-server} --port \${PORT} -m ${model "gemma-4-12b-it-Q6_K.gguf"} -ngl 99 -c 32768 --jinja --temp 1.0 --top-p 0.95 --top-k 64";
             aliases = ["gemma"];
             ttl = 1800;
           };
           "nemotron-nano-12b-v2" = {
-            cmd = "${llama-server} --port \${PORT} -m ${nemotron} -ngl 99 -c 32768 --jinja --temp 0.6 --top-p 0.95";
+            cmd = "${llama-server} --port \${PORT} -m ${model "nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf"} -ngl 99 -c 32768 --jinja --temp 0.6 --top-p 0.95";
             aliases = ["nemotron"];
             ttl = 1800;
           };
         };
       };
+    };
+
+    # Replaces what pkgs.fetchurl used to do at build time: download each
+    # model and refuse to hand it over unless the hash matches. Idempotent, so
+    # it is a no-op on every boot after the first, and re-fetches only a file
+    # that has gone missing or been corrupted.
+    systemd.services.llama-swap-models = {
+      description = "Fetch llama-swap GGUF models";
+      # requiredBy + before rather than a plain wantedBy: llama-swap must not
+      # start against a model file that is absent or half-written. A failed
+      # fetch now holds llama-swap down instead of crash-looping llama-server
+      # against a missing -m argument.
+      before = ["llama-swap.service"];
+      requiredBy = ["llama-swap.service"];
+      after = ["network-online.target"];
+      wants = ["network-online.target"];
+      path = [pkgs.curl pkgs.nix];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        # Tens of GB will blow past the 90s default long before it finishes;
+        # a genuinely dead transfer is caught by curl's --speed-limit instead,
+        # which fails in minutes rather than hanging the boot forever.
+        TimeoutStartSec = "infinity";
+      };
+      # nix-hash --sri prints the same format the `hash` attrs above are
+      # written in, so the check compares against those strings verbatim --
+      # nothing to convert, nothing to keep in sync.
+      script =
+        ''
+          mkdir -p ${modelDir}
+        ''
+        + lib.concatStrings (lib.mapAttrsToList (name: m: ''
+            dest=${model name}
+            if [ "$(nix-hash --type sha256 --sri --flat "$dest" 2>/dev/null || true)" = "${m.hash}" ]; then
+              echo "${name}: present"
+            else
+              echo "${name}: fetching"
+              curl -fL --retry 3 --speed-limit 1024 --speed-time 120 -o "$dest.tmp" "${m.url}"
+              got=$(nix-hash --type sha256 --sri --flat "$dest.tmp")
+              if [ "$got" != "${m.hash}" ]; then
+                echo "${name}: hash mismatch: got $got, want ${m.hash}" >&2
+                rm -f "$dest.tmp"
+                exit 1
+              fi
+              mv "$dest.tmp" "$dest"
+            fi
+          '')
+          models);
     };
 
     systemd.services.llama-swap = {


### PR DESCRIPTION
Fallout from the CI investigation in #95: `toplevel-artemis` is the slowest job
in the matrix by a factor of four, and this is why.

## The problem

The four models were `pkgs.fetchurl` results interpolated into each llama-swap
`cmd`, making them store paths inside `nixos-system-artemis`'s closure —
**34.3 GB** of it:

```
 8.87 GB  Qwen3.5-9B-Q8_0.gguf          9.42 GB  Nemotron-Nano-12B-v2-Q6_K.gguf
 9.11 GB  gemma-4-12b-it-Q6_K.gguf      6.85 GB  ornith-1.0-9b-Q6_K.gguf
```

Every CI leg and every deploy dragged all of it across the network just to
prove the configuration evaluates. That leg runs 574s against ~100s for the
other toplevels, and its 52 GB closure leaves the runner about 18 GB of
headroom — a margin that shrinks with every model added.

## The change

The store was doing three jobs here: fetching, integrity, and surviving the
`nukeRoot` reboot via the persisted `/nix`. That last one is exactly what the
old comment meant by *"hash-pinned into the store so they survive reboots ...
with no impermanence entry"* — so dropping `fetchurl` alone would have
silently re-downloaded tens of GB on every boot.

- `llama-swap-models`, a `oneshot` that fetches and checksums each model,
  takes over fetching and integrity. It verifies with `nix-hash --type sha256
  --sri`, which prints the *same* SRI format the module already stored, so the
  check compares against those strings verbatim — nothing converted, nothing to
  keep in sync.
- A `/var/lib/llama-swap-models` entry in `persistence.directories` takes over
  reboot survival.
- `requiredBy` + `before` on `llama-swap.service`, so a failed or partial fetch
  holds the server down instead of crash-looping `llama-server` against a
  missing `-m` argument.
- `TimeoutStartSec = "infinity"`, since tens of GB blow past the 90s default;
  a genuinely dead transfer is caught by curl's `--speed-limit` instead.

## Verification

The GGUF derivations are gone from artemis's requisite graph, with no other
closure growth:

```
main:  15863 requisites, 4 gguf derivations
here:  15862 requisites, 0 gguf derivations
```

(`pkgs.nix` was already in the closure, so the hashing tool costs nothing.)
`statix` and `treefmt` pass, and the generated unit script was rendered and
read end to end.

## Before activating — seed the models, or artemis re-downloads them

impermanence never migrates data, so the weights have to be copied out of the
store into `/persist` **before** the next GC — into `/persist/var/lib/...`, not
the live `/var/lib/...`, since the bind mount would otherwise hide them.
(`just migrate-persist` is not the tool here: it copies live -> /persist, and
the live path does not exist yet.)

```bash
doas bash <<'EOF'
set -euo pipefail
dest=/persist/var/lib/llama-swap-models
mkdir -p "$dest"
for f in /nix/store/*-*.gguf; do b=${f##*/}; cp -n "$f" "$dest/${b:33}"; done
chmod 0755 "$dest"; chmod 0644 "$dest"/*.gguf
ls -lh "$dest"
EOF
```

`${b:33}` strips the 32-char store hash and its dash. Do **not** use
`${f##*-}` — that strips to the *last* hyphen, collapsing three of the four
models onto `Q6_K.gguf` so they silently clobber each other.

Pre-flight before rebuilding — this predicts whether the unit reports `present`
or starts a 34 GB download:

```bash
doas bash -c 'cd /persist/var/lib/llama-swap-models && for f in *.gguf; do printf "%-46s %s\n" "$f" "$(nix-hash --type sha256 --sri --flat "$f")"; done'
```

All four must match the `hash` values in `modules/nixos/llama-swap.nix`.

Then verify, in order:

- `journalctl -u llama-swap-models` reports four `present` lines, no `fetching`.
- Force a real model load — a status check does not prove file access:
  `curl -s localhost:8080/v1/chat/completions -H 'content-type: application/json' -d '{"model":"ornith","messages":[{"role":"user","content":"hi"}],"max_tokens":8}'`.
  llama-swap runs as `DynamicUser`; `ProtectSystem=strict` should permit reads
  of a 0644 file under a 0755 root-owned dir, but that is the one assumption
  not verifiable from a build. A permission error means the service needs a
  `BindReadOnlyPaths` entry.
- **Reboot and re-check.** Everything above passes on a system whose `/var/lib`
  predates the change; only a reboot proves the persistence entry works. Still
  `present` = correct; `fetching` = nukeRoot ate them.

Keep the store copies until the reboot check passes — do not run
`nix-collect-garbage` before then, or a mistake costs a 34 GB re-download.
Rollback is `doas nixos-rebuild switch --rollback`; the previous generation
still references the store paths.

## Note

Keeps all four models. @jeiang mentioned dropping two unused ones — that is a
clean follow-up commit deleting two `models` entries and their `settings.models`
blocks, and is independent of this mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
