### PR TITLE
feat(monitoring): add a garret dashboard, bump the garret input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1786113766,
-        "narHash": "sha256-f0l5t0ukqW/IFM0JBCvBDw1W4ehnNpOVMf+ArgoeeXI=",
+        "lastModified": 1786132474,
+        "narHash": "sha256-4IWoBD2Cr0Tf+25U5J56HiTJhrTO1OhgRDWu3tmrcr4=",
         "owner": "jeiang",
         "repo": "garret",
-        "rev": "724ca568707e0e92b457981b93cdfaa5c1f375c7",
+        "rev": "35379d63708f5c2d1c8569ff8791805b7e54a4e0",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/monitoring/default.nix
+++ b/modules/nixos/monitoring/default.nix
@@ -188,6 +188,23 @@
         path = ./hath.json;
       }
       {
+        # Hand-authored board for garret, the Nix binary cache (job "garret",
+        # docs/adr/0013). One job, two targets separated by the `component`
+        # label the scrape config below attaches -- pusher (node4:9091) and
+        # puller (node4:9092) -- so every panel selects on `component` rather
+        # than on a second job. Metric names verified against the pinned
+        # garret rev (garret-server/src/{metrics,storage}.rs,
+        # garret-pusher/src/{main,gc}.rs, garret-puller/src/main.rs): a
+        # metrics-exporter-prometheus registry, so counters already carry
+        # `_total` in the source names and only `_bytes`/`_duration_seconds`
+        # suffixes get bucket rules. garret_negotiation_batch_size and
+        # garret_negotiation_missing_ratio match neither rule and so render as
+        # summaries -- their panel averages _sum/_count instead of asking for
+        # a quantile that would not exist.
+        name = "garret.json";
+        path = ./garret.json;
+      }
+      {
         # Vendored "Prometheus Blackbox Exporter" board (grafana.com #7587
         # revision 3). Covers our blackbox-http / blackbox-tcp jobs (the
         # `$target` variable enumerates label_values(probe_success, instance),

--- a/modules/nixos/monitoring/garret.json
+++ b/modules/nixos/monitoring/garret.json
@@ -1,0 +1,1920 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Per-service board for garret, the fleet's Nix binary cache on legion-node4 (docs/adr/0013). One scrape job, job=\"garret\", with two targets distinguished by the `component` label: pusher (:9091) and puller (:9092). Metric names verified against garret rev 724ca56 (garret-server/src/{metrics,storage}.rs, garret-pusher/src/{main,gc}.rs, garret-puller/src/main.rs). Datasource is the fixed provisioned uid \"victoriametrics\"; the Logs row uses \"victorialogs\".",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 2,
+      "type": "row",
+      "title": "Overview",
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 3,
+      "title": "Units up",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Scrape health of the two metrics listeners on legion-node4 (:9091 Pusher, :9092 Puller). 0 means the unit is down or unreachable.",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 5,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "down",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "up",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "up{job=\"garret\"}",
+          "legendFormat": "{{component}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Bucket usage vs quota",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_gc_usage_bytes / garret_gc_quota_bytes, refreshed on every GC timer tick (the counter check is cheap; eviction is what is gated). Eviction starts at the high watermark (0.95) and runs down to the low one (0.85), so a steady reading in that band is the design point, not a problem.",
+      "gridPos": {
+        "x": 5,
+        "y": 1,
+        "w": 5,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.85
+              },
+              {
+                "color": "orange",
+                "value": 0.95
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "garret_gc_usage_bytes{job=\"garret\"} / garret_gc_quota_bytes{job=\"garret\"}",
+          "legendFormat": "used"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Stored bytes",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Bucket usage in bytes, as of the last GC timer tick (garret_gc_usage_bytes).",
+      "gridPos": {
+        "x": 10,
+        "y": 1,
+        "w": 4,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "garret_gc_usage_bytes{job=\"garret\"}",
+          "legendFormat": "used"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Since last eviction pass",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Age of garret_gc_last_success_timestamp. Reads `never` under normal operation and that is correct: the GC timer only sets this gauge when a pass actually evicts, which it does only once usage crosses the high watermark (garret-pusher/src/gc.rs `tick` returns early below it). Treat it as \"when did the quota last bite\", not as a GC liveness check -- for liveness watch the usage gauge, which every tick refreshes.",
+      "gridPos": {
+        "x": 14,
+        "y": 1,
+        "w": 5,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "never",
+                  "color": "text"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "time() - garret_gc_last_success_timestamp{job=\"garret\"}",
+          "legendFormat": "age"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "narinfo hit ratio (5m)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Share of narinfo lookups the index could answer (garret_narinfo_requests_total outcome=hit). Misses are normal -- every substituter asks about paths no cache has -- so read this as a trend, not a target.",
+      "gridPos": {
+        "x": 19,
+        "y": 1,
+        "w": 5,
+        "h": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "special",
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "0"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_narinfo_requests_total{job=\"garret\",component=\"puller\",outcome=\"hit\"}[5m])) / clamp_min(sum(rate(garret_narinfo_requests_total{job=\"garret\",component=\"puller\"}[5m])), 0.0001)",
+          "legendFormat": "hit"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Puller (anonymous substituter, cache.jeiang.dev)",
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "narinfo lookups / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_narinfo_requests_total by outcome. This is what every `nix build` on the fleet hits first.",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum by (outcome) (rate(garret_narinfo_requests_total{job=\"garret\",component=\"puller\"}[5m]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "NAR redirects / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_nar_redirects_total -- each one is a 302 to a presigned S3 URL, so the NAR bytes themselves never pass through this host or the edge.",
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_nar_redirects_total{job=\"garret\",component=\"puller\"}[5m]))",
+          "legendFormat": "redirects/s"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Presign latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_presign_duration_seconds. Sits directly on the substituter's critical path: every NAR fetch waits on it before the client can start downloading.",
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(garret_presign_duration_seconds_bucket{job=\"garret\",component=\"puller\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(garret_presign_duration_seconds_bucket{job=\"garret\",component=\"puller\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Browse API and auth failures / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_browse_requests_total by endpoint (the Pocket ID-gated list/detail/tree/referrers routes) alongside garret_browse_auth_failures_total. Sustained failures usually mean an expired token or a Pocket ID client change, not an attack.",
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum by (endpoint) (rate(garret_browse_requests_total{job=\"garret\",component=\"puller\"}[5m]))",
+          "legendFormat": "{{endpoint}}"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "sum(rate(garret_browse_auth_failures_total{job=\"garret\",component=\"puller\"}[5m]))",
+          "legendFormat": "auth failures"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Last-accessed bump failures / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_bump_failures_total. The LRU bump is fire-and-forget off the request path, so failures do not break substitution -- they starve GC of the access times it evicts by, which quietly makes eviction wrong.",
+      "gridPos": {
+        "x": 12,
+        "y": 15,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_bump_failures_total{job=\"garret\",component=\"puller\"}[5m]))",
+          "legendFormat": "bump failures/s"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Pusher (authenticated push API, cache-push.jeiang.dev)",
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "title": "Upload outcomes / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Accepted, failed, shed (429 past maxConcurrentUploads) and skipped uploads. Skips are the good case: the negotiation step already had the path.",
+      "gridPos": {
+        "x": 0,
+        "y": 23,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_uploads_accepted_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "accepted"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "sum(rate(garret_uploads_failed_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "failed"
+        },
+        {
+          "refId": "C",
+          "range": true,
+          "expr": "sum(rate(garret_uploads_shed_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "shed (429)"
+        },
+        {
+          "refId": "D",
+          "range": true,
+          "expr": "sum by (reason) (rate(garret_upload_skipped_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "skipped ({{reason}})"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Concurrency vs limits",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "In-flight uploads against maxConcurrentUploads, and in-flight bytes ceiling. Riding the upload limit is what produces the shed rate on the left; the byte limit is the real memory bound on a 1.9 GiB node.",
+      "gridPos": {
+        "x": 12,
+        "y": 23,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "upload limit"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "garret_uploads_in_flight{job=\"garret\",component=\"pusher\"}",
+          "legendFormat": "uploads in flight"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "garret_uploads_limit{job=\"garret\",component=\"pusher\"}",
+          "legendFormat": "upload limit"
+        },
+        {
+          "refId": "C",
+          "range": true,
+          "expr": "garret_part_slots_limit{job=\"garret\",component=\"pusher\"}",
+          "legendFormat": "part slots limit"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "title": "Upload size",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_upload_bytes percentiles -- how big the NARs arriving here actually are, which is what partSize (32 MiB) and the 100 MB Cloudflare body limit have to fit.",
+      "gridPos": {
+        "x": 0,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(garret_upload_bytes_bucket{job=\"garret\",component=\"pusher\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(garret_upload_bytes_bucket{job=\"garret\",component=\"pusher\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "title": "Upload duration",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_upload_duration_seconds percentiles: whole streaming PUT, including the S3 write.",
+      "gridPos": {
+        "x": 8,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(garret_upload_duration_seconds_bucket{job=\"garret\",component=\"pusher\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(garret_upload_duration_seconds_bucket{job=\"garret\",component=\"pusher\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "title": "Negotiation",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Mean paths offered per negotiation call and the mean share of them the cache was missing. These two are summaries, not histograms (no bucket rule matches their names in garret-server/src/metrics.rs), so the panel averages _sum/_count rather than asking for a quantile.",
+      "gridPos": {
+        "x": 16,
+        "y": 30,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_negotiation_batch_size_sum{job=\"garret\",component=\"pusher\"}[5m])) / clamp_min(sum(rate(garret_negotiation_batch_size_count{job=\"garret\",component=\"pusher\"}[5m])), 0.0001)",
+          "legendFormat": "mean batch size"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "sum(rate(garret_negotiation_missing_ratio_sum{job=\"garret\",component=\"pusher\"}[5m])) / clamp_min(sum(rate(garret_negotiation_missing_ratio_count{job=\"garret\",component=\"pusher\"}[5m])), 0.0001)",
+          "legendFormat": "mean missing ratio"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "S3 and garbage collection",
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "title": "S3 operations / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Single PutObject calls, multipart parts, deletes and the multipart lifecycle. put failures rising while puts hold steady is the shape of an S3-side problem (credentials, throttling, MEGA S4 outage) rather than a garret one.",
+      "gridPos": {
+        "x": 0,
+        "y": 38,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_s3_puts_total{job=\"garret\"}[5m]))",
+          "legendFormat": "puts"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "sum(rate(garret_s3_parts_total{job=\"garret\"}[5m]))",
+          "legendFormat": "parts"
+        },
+        {
+          "refId": "C",
+          "range": true,
+          "expr": "sum(rate(garret_s3_deletes_total{job=\"garret\"}[5m]))",
+          "legendFormat": "deletes"
+        },
+        {
+          "refId": "D",
+          "range": true,
+          "expr": "sum(rate(garret_s3_put_failures_total{job=\"garret\"}[5m]))",
+          "legendFormat": "put failures"
+        },
+        {
+          "refId": "E",
+          "range": true,
+          "expr": "sum(rate(garret_s3_multipart_started_total{job=\"garret\"}[5m]))",
+          "legendFormat": "multipart started"
+        },
+        {
+          "refId": "F",
+          "range": true,
+          "expr": "sum(rate(garret_s3_multipart_completed_total{job=\"garret\"}[5m]))",
+          "legendFormat": "multipart completed"
+        },
+        {
+          "refId": "G",
+          "range": true,
+          "expr": "sum(rate(garret_s3_multipart_aborted_total{job=\"garret\"}[5m]))",
+          "legendFormat": "multipart aborted"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "title": "S3 bytes uploaded / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_s3_bytes_uploaded_total -- counts both single PutObject bodies and multipart parts, i.e. everything billed as egress into the bucket.",
+      "gridPos": {
+        "x": 12,
+        "y": 38,
+        "w": 6,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_s3_bytes_uploaded_total{job=\"garret\"}[5m]))",
+          "legendFormat": "bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "title": "Part upload latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_s3_part_duration_seconds percentiles: one multipart part (32 MiB at the configured partSize) round-tripping to MEGA S4.",
+      "gridPos": {
+        "x": 18,
+        "y": 38,
+        "w": 6,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(garret_s3_part_duration_seconds_bucket{job=\"garret\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(garret_s3_part_duration_seconds_bucket{job=\"garret\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "title": "Bucket usage vs quota",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_gc_usage_bytes against garret_gc_quota_bytes (250 GiB) over time. Usage steps rather than slopes: it is a SQLite total recomputed on each GC tick, not a continuously updated counter.",
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "quota|watermark"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "garret_gc_usage_bytes{job=\"garret\"}",
+          "legendFormat": "usage"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "garret_gc_quota_bytes{job=\"garret\"}",
+          "legendFormat": "quota"
+        },
+        {
+          "refId": "C",
+          "range": true,
+          "expr": "garret_gc_quota_bytes{job=\"garret\"} * 0.95",
+          "legendFormat": "high watermark"
+        },
+        {
+          "refId": "D",
+          "range": true,
+          "expr": "garret_gc_quota_bytes{job=\"garret\"} * 0.85",
+          "legendFormat": "low watermark"
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "title": "GC work / s",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "Objects and orphans removed per pass, plus stale multiparts aborted. candidates exhausted means GC ran out of evictable objects before reaching the low watermark -- the quota is then effectively unenforceable and the bill stops being bounded.",
+      "gridPos": {
+        "x": 12,
+        "y": 45,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "evicted bytes/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum(rate(garret_gc_evicted_objects_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "evicted objects/s"
+        },
+        {
+          "refId": "B",
+          "range": true,
+          "expr": "sum(rate(garret_gc_evicted_bytes_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "evicted bytes/s"
+        },
+        {
+          "refId": "C",
+          "range": true,
+          "expr": "sum(rate(garret_gc_orphans_deleted_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "orphans deleted/s"
+        },
+        {
+          "refId": "D",
+          "range": true,
+          "expr": "sum(rate(garret_gc_stale_multiparts_aborted_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "stale multiparts/s"
+        },
+        {
+          "refId": "E",
+          "range": true,
+          "expr": "sum(rate(garret_gc_candidates_exhausted_total{job=\"garret\",component=\"pusher\"}[5m]))",
+          "legendFormat": "candidates exhausted/s"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "type": "row",
+      "title": "HTTP (both units)",
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "id": 27,
+      "title": "Requests / s by status class",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_http_requests_total. Status is recorded as a class (2xx/4xx/...) rather than a code, deliberately, to keep series count bounded.",
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "sum by (component, status) (rate(garret_http_requests_total{job=\"garret\"}[5m]))",
+          "legendFormat": "{{component}} {{status}}"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "title": "Request latency p99 by route",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_http_request_duration_seconds. Routes are matched path templates, never concrete store paths.",
+      "gridPos": {
+        "x": 8,
+        "y": 53,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "histogram_quantile(0.99, sum by (le, component, route) (rate(garret_http_request_duration_seconds_bucket{job=\"garret\"}[5m])))",
+          "legendFormat": "{{component}} {{route}}"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "title": "Requests in flight",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "victoriametrics"
+      },
+      "description": "garret_http_requests_in_flight per unit.",
+      "gridPos": {
+        "x": 16,
+        "y": 53,
+        "w": 8,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "none"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "range": true,
+          "expr": "garret_http_requests_in_flight{job=\"garret\"}",
+          "legendFormat": "{{component}}"
+        }
+      ]
+    },
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Logs",
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "panels": [
+        {
+          "id": 101,
+          "type": "logs",
+          "title": "garret logs (pusher + puller)",
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victorialogs"
+          },
+          "description": "Journald logs for both units from VictoriaLogs (datasource uid 'victorialogs'), newest first. Filtered on the verbatim journald unit field _SYSTEMD_UNIT via in(...), same as the other per-service boards. 'Raw Logs' query type (/select/logsql/query).",
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 61
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "showTime": true,
+            "showLabels": false,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "dedupStrategy": "none",
+            "sortOrder": "Descending"
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {
+                "type": "victoriametrics-logs-datasource",
+                "uid": "victorialogs"
+              },
+              "expr": "_SYSTEMD_UNIT:in(\"garret-pusher.service\", \"garret-puller.service\")",
+              "queryType": "instant",
+              "direction": "desc",
+              "maxLines": 500
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "garret",
+    "cache",
+    "nix"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "garret (Nix binary cache)",
+  "uid": "garret",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Grafana had a per-service board for every scrape job except garret, the one that replaced attic (docs/adr/0013). This adds it, and bumps the input to `35379d6`.

## The board

One board, not two: garret is a single scrape job (`job="garret"`) whose two targets are separated by the `component` label the monitoring module already attaches, so every panel selects on that rather than inventing a second job.

- **Overview** — units up, bucket usage vs quota, stored bytes, age of the last eviction pass, narinfo hit ratio
- **Puller** — narinfo lookups by outcome, NAR redirects, presign latency, browse API + auth failures, last-accessed bump failures
- **Pusher** — upload outcomes (accepted/failed/shed/skipped), in-flight vs limits, upload size and duration percentiles, negotiation batch size and missing ratio
- **S3 and GC** — op rates, bytes uploaded, part latency, usage vs quota over time with both watermarks, eviction/orphan work
- **HTTP** — status classes, p99 by route, in-flight
- **Logs** (collapsed) — both units, same `_SYSTEMD_UNIT:in(...)` shape as the other boards

## Two things the metric shapes forced

`garret_negotiation_batch_size` and `garret_negotiation_missing_ratio` match neither bucket rule in `garret-server/src/metrics.rs`, so they render as **summaries**, not histograms — confirmed against the live `/metrics` output. That panel averages `_sum`/`_count` rather than asking for a `_bucket` series that does not exist.

`garret_gc_last_success_timestamp` is only set by `gc.rs run()`, which only runs once usage crosses the high watermark — `tick()` returns early below it. So the stat reads `never` in normal operation, which is correct rather than broken, and its description says so and points at the usage gauge for liveness instead.

## Input bump

`724ca56` → `35379d6`. Adds no metrics and removes none. Upstream gains `services.garret.puller.dbWaitTimeoutSeconds` (default 300, not set here) alongside the Puller change that makes it answer 503 while waiting for the Pusher to create the index instead of dying.

## Verification

Deployed to legion-node3 (Grafana) and legion-node4 (garret). Both units active, both scrape targets `up`, `garret.json` present in the provisioned dashboards store path, no Grafana warnings on start. VictoriaMetrics answers the overview queries live — `garret_gc_usage_bytes/garret_gc_quota_bytes` reads 0.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)