### PR TITLE
feat(artemis): drop the unused gemma and nemotron models

### DIFF
--- a/modules/nixos/llama-swap.nix
+++ b/modules/nixos/llama-swap.nix
@@ -10,8 +10,9 @@ _: {
     llama-server = lib.getExe' llama-cpp "llama-server";
     # Models are fetched at runtime into a persisted directory rather than
     # hash-pinned into the store. As `pkgs.fetchurl` results they were store
-    # paths referenced by each `cmd` below, which put 34 GB of GGUF inside
-    # nixos-system-artemis's closure: every CI leg and every deploy had to
+    # paths referenced by each `cmd` below, which put 34 GB of GGUF (four
+    # models, at the time) inside nixos-system-artemis's closure: every CI leg
+    # and every deploy had to
     # drag all of it over the wire just to prove the configuration evaluates,
     # and it made toplevel-artemis the slowest job in the matrix by a factor
     # of four.
@@ -31,14 +32,6 @@ _: {
       "Qwen3.5-9B-Q8_0.gguf" = {
         url = "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf";
         hash = "sha256-gJYmV00MtD1L7PpWFpmA2iu0SPIpknD3vkQ8uJ0KauQ=";
-      };
-      "gemma-4-12b-it-Q6_K.gguf" = {
-        url = "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-Q6_K.gguf";
-        hash = "sha256-bzlDNlALtUCb1owxqp11CXteYQT2zzDIKgmntk30H68=";
-      };
-      "nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf" = {
-        url = "https://huggingface.co/bartowski/nvidia_NVIDIA-Nemotron-Nano-12B-v2-GGUF/resolve/main/nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf";
-        hash = "sha256-ZZZhGQ2fZQrku6JS3jqI7Qu8tg67ToM8xtHbOWEEFtw=";
       };
     };
     # A plain string, deliberately: interpolating a store path here is exactly
@@ -76,16 +69,6 @@ _: {
           "qwen3.5-9b" = {
             cmd = "${llama-server} --port \${PORT} -m ${model "Qwen3.5-9B-Q8_0.gguf"} -ngl 99 -c 40960 --jinja --temp 0.6 --top-p 0.95 --top-k 20";
             aliases = ["qwen"];
-            ttl = 1800;
-          };
-          "gemma-4-12b" = {
-            cmd = "${llama-server} --port \${PORT} -m ${model "gemma-4-12b-it-Q6_K.gguf"} -ngl 99 -c 32768 --jinja --temp 1.0 --top-p 0.95 --top-k 64";
-            aliases = ["gemma"];
-            ttl = 1800;
-          };
-          "nemotron-nano-12b-v2" = {
-            cmd = "${llama-server} --port \${PORT} -m ${model "nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf"} -ngl 99 -c 32768 --jinja --temp 0.6 --top-p 0.95";
-            aliases = ["nemotron"];
             ttl = 1800;
           };
         };


### PR DESCRIPTION
Neither model is used. Removes both from `llama-swap-models`' fetch set and
from `services.llama-swap.settings.models`.

| | | |
|---|---|---|
| kept | `ornith-1.0-9b-Q6_K.gguf` | 6.85 GB |
| kept | `Qwen3.5-9B-Q8_0.gguf` | 8.87 GB |
| removed | `gemma-4-12b-it-Q6_K.gguf` | 9.11 GB |
| removed | `nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf` | 9.42 GB |

34.3 GB → **15.7 GB**, and it drops the two largest single files.

No closure effect — #96 already took the weights out of
`nixos-system-artemis` entirely, so this only changes what the host fetches and
stores at runtime. Verified: still 0 gguf derivations in artemis's requisite
graph.

## Verification

- `systemd.services.llama-swap-models.script` renders exactly two `dest=` lines
  (ornith, qwen).
- `services.llama-swap.settings.models` evaluates to `["ornith-1.0-9b", "qwen3.5-9b"]`.
- `statix` and `treefmt` pass.

## The unit does not prune

`gemma` and `nemotron` will sit in `/var/lib/llama-swap-models` until deleted by
hand. That is deliberate: auto-pruning a directory of multi-GB files against a
computed name list has a much worse failure mode than a stale file — one typo in
a model name and it deletes weights it was meant to keep.

Reclaim the 18.5 GB manually, **after** activating this. Delete from `/persist`,
which is the real storage — the live path is a bind mount over it:

```bash
doas rm -f /persist/var/lib/llama-swap-models/gemma-4-12b-it-Q6_K.gguf /persist/var/lib/llama-swap-models/nvidia_NVIDIA-Nemotron-Nano-12B-v2-Q6_K.gguf
```

## If artemis has not activated #96 yet

Merge this one first. The seed step in #96 copies `/nix/store/*-*.gguf`, which
still globs all four while the old generation is live — so following it as
written would seed two files that this PR immediately turns into orphans.

Seed only what is kept:

```bash
doas bash <<'SEED'
set -euo pipefail
dest=/persist/var/lib/llama-swap-models
mkdir -p "$dest"
for n in ornith-1.0-9b-Q6_K.gguf Qwen3.5-9B-Q8_0.gguf; do
  src=$(echo /nix/store/*-"$n"); cp -n "$src" "$dest/$n"
done
chmod 0755 "$dest"; chmod 0644 "$dest"/*.gguf
ls -lh "$dest"
SEED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
