### PR TITLE
docs(hermes): pin down the ICLOUD_USERNAME format in the runbook

### DIFF
--- a/docs/runbooks/hermes.md
+++ b/docs/runbooks/hermes.md
@@ -97,10 +97,24 @@ node as a `hermes-ops` recipient).
 - **iCloud app-specific password (CalDAV/CardDAV)** -- `ICLOUD_APP_PASSWORD`,
   another `hermes/env` line, generated from Aidan's Apple ID account page
   (appleid.apple.com -> Sign-In and Security -> App-Specific Passwords).
-  `ICLOUD_USERNAME` (Aidan's iCloud email, not itself a credential but
-  operator-specific) sits alongside it in the same secret. Both consumed
-  by vdirsyncer's `username.fetch`/`password.fetch` (`["command",
-  "printenv", "..."]`, `modules/nixos/hermes/default.nix`'s
+  `ICLOUD_USERNAME` (not itself a credential but operator-specific) sits
+  alongside it in the same secret. It must be a **full email address** --
+  either the Apple ID sign-in address or the `@icloud.com` one, both of
+  which work. It must NOT be the bare Apple ID short name: that
+  authenticates successfully against the account and then fails CalDAV
+  principal lookup, so iCloud answers `403 Forbidden` rather than `401`,
+  and the unit's log looks like a permissions problem instead of a
+  malformed username. Check a candidate before committing it -- `207` is
+  the pass, `403` means the address has no CalDAV principal, `401` means
+  the credential pair itself is wrong:
+
+  ```sh
+  curl -s -o /dev/null -w '%{http_code}\n' -X PROPFIND -H 'Depth: 0' \
+    -u 'ADDRESS:APP_SPECIFIC_PASSWORD' https://caldav.icloud.com/
+  ```
+
+  Both are consumed by vdirsyncer's `username.fetch`/`password.fetch`
+  (`["command", "printenv", "..."]`, `modules/nixos/hermes/default.nix`'s
   `vdirsyncerConfig`) from the `hermes-vdirsyncer-sync` unit's
   environment -- khal itself never touches iCloud directly, it only reads
   the local vdir vdirsyncer maintains. Revoke from the same Apple ID page;


### PR DESCRIPTION
Docs only — no module change, nothing to deploy.

The credential inventory described `ICLOUD_USERNAME` as "Aidan's iCloud email", which is the ambiguity that cost three debugging passes in #100 and #101. The value in the secret was the bare Apple ID short name; that authenticates successfully against the account and *then* fails CalDAV principal lookup, so iCloud answers `403 Forbidden` rather than `401 Unauthorized` — making the unit look like a permissions or entitlement problem rather than a malformed username.

This spells out that the value must be a full email address (sign-in address or `@icloud.com`, both verified working), that the bare short name is the trap, and adds the `PROPFIND` check that settles it before a value is committed:

- `207` — address is good
- `403` — authenticates, but no CalDAV principal (wrong address form)
- `401` — the credential pair itself is wrong

Relevant on rotation too: the app-specific password is regenerated from the same Apple ID page, and it's easy to re-enter the username at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)